### PR TITLE
Polish language and fix typos

### DIFF
--- a/draft-ounsworth-cfrg-kem-combiners.html
+++ b/draft-ounsworth-cfrg-kem-combiners.html
@@ -1181,7 +1181,7 @@ li > p:last-of-type {
 </tr></thead>
 <tfoot><tr>
 <td class="left">Ounsworth &amp; Wussler</td>
-<td class="center">Expires 8 September 2023</td>
+<td class="center">Expires 9 September 2023</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -1194,12 +1194,12 @@ li > p:last-of-type {
 <dd class="internet-draft">draft-ounsworth-cfrg-kem-combiners-00</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2023-03-07" class="published">7 March 2023</time>
+<time datetime="2023-03-08" class="published">8 March 2023</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Informational</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2023-09-08">8 September 2023</time></dd>
+<dd class="expires"><time datetime="2023-09-09">9 September 2023</time></dd>
 <dt class="label-authors">Authors:</dt>
 <dd class="authors">
 <div class="author">
@@ -1253,7 +1253,7 @@ li > p:last-of-type {
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on 8 September 2023.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on 9 September 2023.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">
@@ -1387,7 +1387,7 @@ def kemDecaps(ct, sk) -&gt; ss
         <li id="section-2-2.3">KEM-based authenticated key exchanges (AKEs) where the output of two or more KEMs performed in different directions are combined.<a href="#section-2-2.3" class="pilcrow">¶</a>
 </li>
       </ol>
-<p id="section-2-3">This document normalizes a mechanisms for combining the output of two or more KEMs.<a href="#section-2-3" class="pilcrow">¶</a></p>
+<p id="section-2-3">This document normalizes a mechanism for combining the output of two or more KEMs.<a href="#section-2-3" class="pilcrow">¶</a></p>
 <div id="kempsk-hybrids">
 <section id="section-2.1">
         <h3 id="name-kem-psk-hybrids-2">
@@ -1434,7 +1434,7 @@ ss = kemCombiner(ss_1, ss_2, ..., ss_n)
 </pre><a href="#section-3-2" class="pilcrow">¶</a>
 </div>
 <p id="section-3-3">This document assumes that shared secrets are the output of a KEM, but without loss of generality they MAY also be any other source of cryptographic key material, such as pre-shared keys (PSKs), with PQ/PSK being a quantum-safe migration strategy being made available by some protocols, see for example IKEv2 in <span>[<a href="#RFC8784" class="xref">RFC8784</a>]</span>.<a href="#section-3-3" class="pilcrow">¶</a></p>
-<p id="section-3-4">In general it is desirable to use a multi-PRF as a KEM combiner, a function that can be keyed by any input.
+<p id="section-3-4">In general it is desirable to use a multi-PRF as a KEM combiner, meaning a PRF when keyed by any of its single inputs.
 The following simple yet generic construction can be used in all IETF protocols that need to combine the output of two or more KEMs:<a href="#section-3-4" class="pilcrow">¶</a></p>
 <span id="name-general-kem-combiner-constru"></span><figure id="figure-1">
         <div class="alignLeft art-text artwork" id="section-3-5.1">
@@ -1490,19 +1490,21 @@ In cases some variable length input is necessary, such as the representation of 
 </li>
           <li class="normal" id="section-3.1-4.2">The public keys or certificates contributed by each party to the key-agreement transaction.<a href="#section-3.1-4.2" class="pilcrow">¶</a>
 </li>
-          <li class="normal" id="section-3.1-4.3">Other public and/or private information shared between communication parties before or during the transaction, such as nonces or pre-shared secrets.<a href="#section-3.1-4.3" class="pilcrow">¶</a>
+          <li class="normal" id="section-3.1-4.3">The ciphertext of each Key Encapsulation Mechanism.<a href="#section-3.1-4.3" class="pilcrow">¶</a>
 </li>
-          <li class="normal" id="section-3.1-4.4">An indication of the protocol or application employing the key-derivation method.<a href="#section-3.1-4.4" class="pilcrow">¶</a>
+          <li class="normal" id="section-3.1-4.4">Other public information shared between communication parties before or during the transaction, such as nonces.<a href="#section-3.1-4.4" class="pilcrow">¶</a>
 </li>
-          <li class="normal" id="section-3.1-4.5">Protocol-related information, such as a label or session identifier.<a href="#section-3.1-4.5" class="pilcrow">¶</a>
+          <li class="normal" id="section-3.1-4.5">An indication of the protocol or application employing the key-derivation method.<a href="#section-3.1-4.5" class="pilcrow">¶</a>
 </li>
-          <li class="normal" id="section-3.1-4.6">An indication of the key-agreement scheme and/or key-derivation method used.<a href="#section-3.1-4.6" class="pilcrow">¶</a>
+          <li class="normal" id="section-3.1-4.6">Protocol-related information, such as a label or session identifier.<a href="#section-3.1-4.6" class="pilcrow">¶</a>
 </li>
-          <li class="normal" id="section-3.1-4.7">An indication of the domain parameters associated with the asymmetric key pairs employed for key establishment.<a href="#section-3.1-4.7" class="pilcrow">¶</a>
+          <li class="normal" id="section-3.1-4.7">An indication of the key-agreement scheme and/or key-derivation method used.<a href="#section-3.1-4.7" class="pilcrow">¶</a>
 </li>
-          <li class="normal" id="section-3.1-4.8">An indication of other parameter or primitive choices.<a href="#section-3.1-4.8" class="pilcrow">¶</a>
+          <li class="normal" id="section-3.1-4.8">An indication of the domain parameters associated with the asymmetric key pairs employed for key establishment.<a href="#section-3.1-4.8" class="pilcrow">¶</a>
 </li>
-          <li class="normal" id="section-3.1-4.9">An indication of how the derived keying material should be parsed, including an indication of which algorithm(s) will use the (parsed) keying material.<a href="#section-3.1-4.9" class="pilcrow">¶</a>
+          <li class="normal" id="section-3.1-4.9">An indication of other parameter or primitive choices.<a href="#section-3.1-4.9" class="pilcrow">¶</a>
+</li>
+          <li class="normal" id="section-3.1-4.10">An indication of how the derived keying material should be parsed, including an indication of which algorithm(s) will use the (parsed) keying material.<a href="#section-3.1-4.10" class="pilcrow">¶</a>
 </li>
         </ul>
 <p id="section-3.1-5">This is a non-comprehensive list, further information can be found in paragraph 5.8.2 of NIST SP800-56Ar3 <span>[<a href="#SP800-56A" class="xref">SP800-56A</a>]</span>.<a href="#section-3.1-5" class="pilcrow">¶</a></p>
@@ -1539,7 +1541,7 @@ Each instance defines a function to be used as <code>KDF</code>, a hash <code>H<
 <p id="section-4.1-1">Options 1 and 2 instantiate the KDF using SHA3, specified in NIST FIPS 202 <span>[<a href="#FIPS202" class="xref">FIPS202</a>]</span>.
 To generate an <code>outputBits</code> long secret share <code>ss</code>:<a href="#section-4.1-1" class="pilcrow">¶</a></p>
 <ul class="normal">
-<li class="normal" id="section-4.1-2.1">the <code>counter</code> MUST be initialized with the string <code>0x00000001</code>.<a href="#section-4.1-2.1" class="pilcrow">¶</a>
+<li class="normal" id="section-4.1-2.1">the <code>counter</code> MUST be initialized with the value <code>0x00000001</code>.<a href="#section-4.1-2.1" class="pilcrow">¶</a>
 </li>
           <li class="normal" id="section-4.1-2.2">The hash is performed over the string defined in <a href="#sec-kem-combiner" class="xref">Section 3</a>, and repeated <code>ceil(outputBits/hashSize)</code> times. For each iteration the <code>counter</code> MUST be increased by <code>0x01</code>.<a href="#section-4.1-2.2" class="pilcrow">¶</a>
 </li>
@@ -1563,10 +1565,11 @@ To instantiate the function:<a href="#section-4.2-1" class="pilcrow">¶</a></p>
 </li>
           <li class="normal" id="section-4.2-2.2">The key <code>K</code> MUST be a context-specific string of at least <code>hashSize</code> bits, and it MAY be used as an additional option to perform context separation, in scenarios where <code>fixedInfo</code> is not sufficient.<a href="#section-4.2-2.2" class="pilcrow">¶</a>
 </li>
-          <li class="normal" id="section-4.2-2.3">The parameter <code>counter</code> MUST be the fixed string <code>0x00000001</code>.<a href="#section-4.2-2.3" class="pilcrow">¶</a>
+          <li class="normal" id="section-4.2-2.3">The parameter <code>counter</code> MUST be the fixed value <code>0x00000001</code>.<a href="#section-4.2-2.3" class="pilcrow">¶</a>
 </li>
         </ul>
-<p id="section-4.2-3">To derive a shared secret <code>ss</code> of desired length, KMAC is called a single time with the input string <code>X</code> defined in <a href="#sec-kem-combiner" class="xref">Section 3</a> and length <code>L</code> being <code>outputBits</code>.<a href="#section-4.2-3" class="pilcrow">¶</a></p>
+<p id="section-4.2-3">To derive a shared secret <code>ss</code> of desired length, KMAC is called a single time with the input string <code>X</code> defined in <a href="#sec-kem-combiner" class="xref">Section 3</a> and length <code>L</code> being <code>outputBits</code>.
+This is compatible with the one-step KDF definition given in NIST SP800-56Cr2 <span>[<a href="#SP800-56C" class="xref">SP800-56C</a>]</span>, Section 4.<a href="#section-4.2-3" class="pilcrow">¶</a></p>
 </section>
 </div>
 </section>

--- a/draft-ounsworth-cfrg-kem-combiners.html
+++ b/draft-ounsworth-cfrg-kem-combiners.html
@@ -21,7 +21,6 @@
 <!-- Generator version information:
   xml2rfc 3.12.2
     Python 3.10.6
-    weasyprint 54.1
 -->
 <link href="draft-ounsworth-cfrg-kem-combiners.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
@@ -1182,7 +1181,7 @@ li > p:last-of-type {
 </tr></thead>
 <tfoot><tr>
 <td class="left">Ounsworth &amp; Wussler</td>
-<td class="center">Expires 5 September 2023</td>
+<td class="center">Expires 8 September 2023</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -1195,12 +1194,12 @@ li > p:last-of-type {
 <dd class="internet-draft">draft-ounsworth-cfrg-kem-combiners-00</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2023-03-04" class="published">4 March 2023</time>
+<time datetime="2023-03-07" class="published">7 March 2023</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Informational</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2023-09-05">5 September 2023</time></dd>
+<dd class="expires"><time datetime="2023-09-08">8 September 2023</time></dd>
 <dt class="label-authors">Authors:</dt>
 <dd class="authors">
 <div class="author">
@@ -1254,7 +1253,7 @@ li > p:last-of-type {
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on 5 September 2023.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on 8 September 2023.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">
@@ -1368,7 +1367,7 @@ def kemEncaps(pk) -&gt; (ct, ss)
 def kemDecaps(ct, sk) -&gt; ss
 </pre><a href="#section-1.1-2" class="pilcrow">¶</a>
 </div>
-<p id="section-1.1-3">where <code>pk</code> is public key, <code>sk</code> is secret key, <code>ct</code> is the ciphertext repseresting an encapsulated key, and <code>ss</code> is shared secret.<a href="#section-1.1-3" class="pilcrow">¶</a></p>
+<p id="section-1.1-3">where <code>pk</code> is public key, <code>sk</code> is secret key, <code>ct</code> is the ciphertext representing an encapsulated key, and <code>ss</code> is shared secret.<a href="#section-1.1-3" class="pilcrow">¶</a></p>
 <p id="section-1.1-4">KEMs are typically used in cases where two parties, hereby refereed to as the "encapsulater" and the "decapsulater", wish to establish a shared secret via public key cryptography, where the decapsulater has an asymmetric key pair and has previously shared the public key with the encapsulater.<a href="#section-1.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
@@ -1383,9 +1382,9 @@ def kemDecaps(ct, sk) -&gt; ss
 <ol start="1" type="1" class="normal type-1" id="section-2-2">
 <li id="section-2-2.1">KEM / PSK hybrids where the output of a KEM is combined with a static pre-shared key.<a href="#section-2-2.1" class="pilcrow">¶</a>
 </li>
-        <li id="section-2-2.2">Post-quantum / traditional hybrid KEMs where output of a post-quantum KEM is combined with the output of a classical key transport or key exchenge algorithm.<a href="#section-2-2.2" class="pilcrow">¶</a>
+        <li id="section-2-2.2">Post-quantum / traditional hybrid KEMs where output of a post-quantum KEM is combined with the output of a classical key transport or key exchange algorithm.<a href="#section-2-2.2" class="pilcrow">¶</a>
 </li>
-        <li id="section-2-2.3">KEM-based authenticated key exchanges (AKEs) where the ouput of two or more KEMs performed in different directions are combined.<a href="#section-2-2.3" class="pilcrow">¶</a>
+        <li id="section-2-2.3">KEM-based authenticated key exchanges (AKEs) where the output of two or more KEMs performed in different directions are combined.<a href="#section-2-2.3" class="pilcrow">¶</a>
 </li>
       </ol>
 <p id="section-2-3">This document normalizes a mechanisms for combining the output of two or more KEMs.<a href="#section-2-3" class="pilcrow">¶</a></p>
@@ -1418,7 +1417,7 @@ def kemDecaps(ct, sk) -&gt; ss
         <h3 id="name-kem-based-ake-2">
 <a href="#section-2.3" class="section-number selfRef">2.3. </a><a href="#name-kem-based-ake-2" class="section-name selfRef">KEM-based AKE</a>
         </h3>
-<p id="section-2.3-1">The need for a KEM-based authenticated key establishment arises, for example, when two communicating parties each have long-term KEM keys (for example in X.509 certificates), and wish to involve both KEM keys in deriving a mutually-authenticated shared secret. In particular this will arise for any protocol that needs to provide post-quantum replacements for static-static (Elliptic Curve) Diffie-Hellman mechanisms. Examples include a KEM replacement for CMP's DHBasedMac <span>[<a href="#I-D.ietf-lamps-cmp-updates" class="xref">I-D.ietf-lamps-cmp-updates</a>]</span>, .. TODO: cite others.<a href="#section-2.3-1" class="pilcrow">¶</a></p>
+<p id="section-2.3-1">The need for a KEM-based authenticated key establishment arises, for example, when two communicating parties each have long-term KEM keys (for example in X.509 certificates), and wish to involve both KEM keys in deriving a mutually-authenticated shared secret. In particular this will arise for any protocol that needs to provide post-quantum replacements for static-static (Elliptic Curve) Diffie-Hellman mechanisms. Examples include a KEM replacement for CMP's DHBasedMac <span>[<a href="#I-D.ietf-lamps-cmp-updates" class="xref">I-D.ietf-lamps-cmp-updates</a>]</span>.<a href="#section-2.3-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 </section>
@@ -1428,10 +1427,10 @@ def kemDecaps(ct, sk) -&gt; ss
       <h2 id="name-kem-combiner-construction-2">
 <a href="#section-3" class="section-number selfRef">3. </a><a href="#name-kem-combiner-construction-2" class="section-name selfRef">KEM Combiner construction</a>
       </h2>
-<p id="section-3-1">A KEM combiner is a function that takes in two or more shared secrets <code>SS_i</code> and returns a combined shared secret <code>SS</code>, where all values are byte arrays.<a href="#section-3-1" class="pilcrow">¶</a></p>
+<p id="section-3-1">A KEM combiner is a function that takes in two or more shared secrets <code>ss_i</code> and returns a combined shared secret <code>ss</code>, where all values are byte arrays.<a href="#section-3-1" class="pilcrow">¶</a></p>
 <div class="alignLeft art-text artwork" id="section-3-2">
 <pre>
-SS = kemCombiner(SS_1, SS_2, ..., SS_n)
+ss = kemCombiner(ss_1, ss_2, ..., ss_n)
 </pre><a href="#section-3-2" class="pilcrow">¶</a>
 </div>
 <p id="section-3-3">This document assumes that shared secrets are the output of a KEM, but without loss of generality they MAY also be any other source of cryptographic key material, such as pre-shared keys (PSKs), with PQ/PSK being a quantum-safe migration strategy being made available by some protocols, see for example IKEv2 in <span>[<a href="#RFC8784" class="xref">RFC8784</a>]</span>.<a href="#section-3-3" class="pilcrow">¶</a></p>
@@ -1440,7 +1439,7 @@ The following simple yet generic construction can be used in all IETF protocols 
 <span id="name-general-kem-combiner-constru"></span><figure id="figure-1">
         <div class="alignLeft art-text artwork" id="section-3-5.1">
 <pre>
-KDF(counter || K_1 || ... || K_n || fixedInfo, outputBits)
+KDF(counter || k_1 || ... || k_n || fixedInfo, outputBits)
 </pre>
 </div>
 <figcaption><a href="#figure-1" class="selfRef">Figure 1</a>:
@@ -1452,7 +1451,7 @@ KDF(counter || K_1 || ... || K_n || fixedInfo, outputBits)
           <code>KDF</code> represents a suitable choice of cryptographic key derivation function,<a href="#section-3-7.1" class="pilcrow">¶</a>
 </li>
         <li class="normal" id="section-3-7.2">
-          <code>K_i</code> represent the constant-length input keys,<a href="#section-3-7.2" class="pilcrow">¶</a>
+          <code>k_i</code> represent the constant-length input keys,<a href="#section-3-7.2" class="pilcrow">¶</a>
 </li>
         <li class="normal" id="section-3-7.3">
           <code>fixedInfo</code> is some protocol-specific KDF binding,<a href="#section-3-7.3" class="pilcrow">¶</a>
@@ -1467,14 +1466,15 @@ KDF(counter || K_1 || ... || K_n || fixedInfo, outputBits)
           <code>||</code> represents concatenation.<a href="#section-3-7.6" class="pilcrow">¶</a>
 </li>
       </ul>
-<p id="section-3-8">In section <a href="#sec-instantiation" class="xref">Section 4</a> are listed several possible practical instantiations, in compliance with NIST SP-800 56Cr2 <span>[<a href="#SP800-56C" class="xref">SP800-56C</a>]</span>.<a href="#section-3-8" class="pilcrow">¶</a></p>
-<p id="section-3-9">Each <code>K_i</code> MUST be constant in length, therefore the secret shares <code>SS_i</code> can be used directly only if they are guaranteed to be constant length. For all other cases, it is REQUIRED to hash them first:<a href="#section-3-9" class="pilcrow">¶</a></p>
+<p id="section-3-8">In section <a href="#sec-instantiation" class="xref">Section 4</a> are listed several possible practical instantiations, in compliance with NIST SP-800 56Cr2 <span>[<a href="#SP800-56C" class="xref">SP800-56C</a>]</span>.
+The shared secret <code>ss</code> MAY be used as a Key Encryption Key (KEK) for key encapsulation.<a href="#section-3-8" class="pilcrow">¶</a></p>
+<p id="section-3-9">Each <code>k_i</code> MUST be constant in length, therefore the secret shares <code>ss_i</code> can be used directly only if they are guaranteed to be constant length. For all other cases, it is REQUIRED to hash them first:<a href="#section-3-9" class="pilcrow">¶</a></p>
 <div class="alignLeft art-text artwork" id="section-3-10">
 <pre>
-K_i = H(SS_i)
+k_i = H(ss_i)
 </pre><a href="#section-3-10" class="pilcrow">¶</a>
 </div>
-<p id="section-3-11">Any protocols making use of this construction MUST either hash all inputs <code>SS_i</code>, or justify that any un-hashed inputs will always be fixed length.<a href="#section-3-11" class="pilcrow">¶</a></p>
+<p id="section-3-11">Any protocols making use of this construction MUST either hash all inputs <code>ss_i</code>, or justify that any un-hashed inputs will always be fixed length.<a href="#section-3-11" class="pilcrow">¶</a></p>
 <div id="protocol-binding">
 <section id="section-3.1">
         <h3 id="name-protocol-binding-2">
@@ -1516,7 +1516,7 @@ In cases some variable length input is necessary, such as the representation of 
 <a href="#section-4" class="section-number selfRef">4. </a><a href="#name-practical-instantiations-2" class="section-name selfRef">Practical instantiations</a>
       </h2>
 <p id="section-4-1">The KDF MUST be instantiated with one of the following Keccak-based option.
-Each instance defines a function to be used as <code>KDF</code>, a hash <code>H</code> function to optionally derive the <code>K_i</code>, and a <code>counter</code>.<a href="#section-4-1" class="pilcrow">¶</a></p>
+Each instance defines a function to be used as <code>KDF</code>, a hash <code>H</code> function to optionally derive the <code>k_i</code>, and a <code>counter</code>.<a href="#section-4-1" class="pilcrow">¶</a></p>
 <ol start="1" type="1" class="normal type-1" id="section-4-2">
 <li id="section-4-2.1">
           <code>KDF = SHA3-256</code> and <code>H = SHA3-256</code>, with <code>hashSize = 256 bit</code>.<a href="#section-4-2.1" class="pilcrow">¶</a>
@@ -1537,7 +1537,7 @@ Each instance defines a function to be used as <code>KDF</code>, a hash <code>H<
 <a href="#section-4.1" class="section-number selfRef">4.1. </a><a href="#name-hash-and-counter-based-const" class="section-name selfRef">Hash-and-counter based construction</a>
         </h3>
 <p id="section-4.1-1">Options 1 and 2 instantiate the KDF using SHA3, specified in NIST FIPS 202 <span>[<a href="#FIPS202" class="xref">FIPS202</a>]</span>.
-To generate an <code>outputBits</code> long secret share <code>SS</code>:<a href="#section-4.1-1" class="pilcrow">¶</a></p>
+To generate an <code>outputBits</code> long secret share <code>ss</code>:<a href="#section-4.1-1" class="pilcrow">¶</a></p>
 <ul class="normal">
 <li class="normal" id="section-4.1-2.1">the <code>counter</code> MUST be initialized with the string <code>0x00000001</code>.<a href="#section-4.1-2.1" class="pilcrow">¶</a>
 </li>
@@ -1545,7 +1545,7 @@ To generate an <code>outputBits</code> long secret share <code>SS</code>:<a href
 </li>
           <li class="normal" id="section-4.1-2.3">The strings are concatenated ordered by <code>counter</code>.<a href="#section-4.1-2.3" class="pilcrow">¶</a>
 </li>
-          <li class="normal" id="section-4.1-2.4">The leftmost <code>outputBits</code> are returned as <code>SS</code>.<a href="#section-4.1-2.4" class="pilcrow">¶</a>
+          <li class="normal" id="section-4.1-2.4">The leftmost <code>outputBits</code> are returned as <code>ss</code>.<a href="#section-4.1-2.4" class="pilcrow">¶</a>
 </li>
         </ul>
 <p id="section-4.1-3">An implementation MUST NOT overflow and reuse the <code>counter</code> and an error MUST be returned when producing more than 2^32 consecutive hashes.<a href="#section-4.1-3" class="pilcrow">¶</a></p>
@@ -1557,9 +1557,16 @@ To generate an <code>outputBits</code> long secret share <code>SS</code>:<a href
 <a href="#section-4.2" class="section-number selfRef">4.2. </a><a href="#name-kmac-based-construction-2" class="section-name selfRef">KMAC based construction</a>
         </h3>
 <p id="section-4.2-1">Options 3 and 4 are KMAC-based, as specified in NIST SP 800-185 <span>[<a href="#SP800-185" class="xref">SP800-185</a>]</span>.
-The context <code>S</code> MUST be the utf-8 string "KDF", the key <code>K</code> MUST be a context-specific string of at least <code>hashSize</code> bits, and <code>counter</code> MUST be the fixed string <code>0x00000001</code>.
-The key <code>K</code> MAY be used as an additional option to perform context separation, in scenarios where <code>fixedInfo</code> is not sufficient.<a href="#section-4.2-1" class="pilcrow">¶</a></p>
-<p id="section-4.2-2">To derive a shared secret <code>SS</code> of desired length, KMAC is called a single time with the input string <code>X</code> defined in <a href="#sec-kem-combiner" class="xref">Section 3</a> and length <code>L</code> being <code>outputBits</code>.<a href="#section-4.2-2" class="pilcrow">¶</a></p>
+To instantiate the function:<a href="#section-4.2-1" class="pilcrow">¶</a></p>
+<ul class="normal">
+<li class="normal" id="section-4.2-2.1">The context <code>S</code> MUST be the utf-8 string "KDF".<a href="#section-4.2-2.1" class="pilcrow">¶</a>
+</li>
+          <li class="normal" id="section-4.2-2.2">The key <code>K</code> MUST be a context-specific string of at least <code>hashSize</code> bits, and it MAY be used as an additional option to perform context separation, in scenarios where <code>fixedInfo</code> is not sufficient.<a href="#section-4.2-2.2" class="pilcrow">¶</a>
+</li>
+          <li class="normal" id="section-4.2-2.3">The parameter <code>counter</code> MUST be the fixed string <code>0x00000001</code>.<a href="#section-4.2-2.3" class="pilcrow">¶</a>
+</li>
+        </ul>
+<p id="section-4.2-3">To derive a shared secret <code>ss</code> of desired length, KMAC is called a single time with the input string <code>X</code> defined in <a href="#sec-kem-combiner" class="xref">Section 3</a> and length <code>L</code> being <code>outputBits</code>.<a href="#section-4.2-3" class="pilcrow">¶</a></p>
 </section>
 </div>
 </section>
@@ -1580,7 +1587,7 @@ The key <code>K</code> MAY be used as an additional option to perform context se
 <p id="section-6-1">The proposed instantiations in <a href="#sec-instantiation" class="xref">Section 4</a> are practical multi-PRFs and this specification limits to the use of Keccak-based constructions. The sponge construction was proven to be indifferentiable from a random oracle <span>[<a href="#SPONGE" class="xref">SPONGE</a>]</span>.
 More precisely, for a given capacity <code>c</code> the indifferentiability proof shows that assuming there are no weaknesses found in the Keccak permutation, an attacker has to make an expected number of <code>2^(c/2)</code> calls to the permutation to tell Keccak from a random oracle.
 For a random oracle, a difference in only a single bit gives an unrelated, uniformly random output.
-Hence, to be able to distinguish a key <code>K</code>, derived from shared keys <code>K_i</code> from a random bit string, an adversary has to correctly guess all key shares <code>K_i</code> entirely.<a href="#section-6-1" class="pilcrow">¶</a></p>
+Hence, to be able to distinguish a key <code>k</code>, derived from shared keys <code>k_i</code> from a random bit string, an adversary has to correctly guess all key shares <code>k_i</code> entirely.<a href="#section-6-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <section id="section-7">

--- a/draft-ounsworth-cfrg-kem-combiners.mkd
+++ b/draft-ounsworth-cfrg-kem-combiners.mkd
@@ -182,7 +182,7 @@ The need for a KEM combiner function arises in three different contexts within I
 
 1. KEM / PSK hybrids where the output of a KEM is combined with a static pre-shared key.
 1. Post-quantum / traditional hybrid KEMs where output of a post-quantum KEM is combined with the output of a classical key transport or key exchange algorithm.
-1. KEM-based authenticated key exchanges (AKEs) where the ouput of two or more KEMs performed in different directions are combined.
+1. KEM-based authenticated key exchanges (AKEs) where the output of two or more KEMs performed in different directions are combined.
 
 This document normalizes a mechanisms for combining the output of two or more KEMs.
 
@@ -202,7 +202,7 @@ Building a PQ/T hybrid KEM requires a secure function which combines the output 
 
 ## KEM-based AKE
 
-The need for a KEM-based authenticated key establishment arises, for example, when two communicating parties each have long-term KEM keys (for example in X.509 certificates), and wish to involve both KEM keys in deriving a mutually-authenticated shared secret. In particular this will arise for any protocol that needs to provide post-quantum replacements for static-static (Elliptic Curve) Diffie-Hellman mechanisms. Examples include a KEM replacement for CMP's DHBasedMac {{I-D.ietf-lamps-cmp-updates}}, .. TODO: cite others.
+The need for a KEM-based authenticated key establishment arises, for example, when two communicating parties each have long-term KEM keys (for example in X.509 certificates), and wish to involve both KEM keys in deriving a mutually-authenticated shared secret. In particular this will arise for any protocol that needs to provide post-quantum replacements for static-static (Elliptic Curve) Diffie-Hellman mechanisms. Examples include a KEM replacement for CMP's DHBasedMac {{I-D.ietf-lamps-cmp-updates}}.
 
 
 # KEM Combiner construction {#sec-kem-combiner}
@@ -220,10 +220,10 @@ and Practice of Public Key Cryptography, Part I, volume 10769 of Lecture Notes i
 -->
 
 
-A KEM combiner is a function that takes in two or more shared secrets `SS_i` and returns a combined shared secret `SS`, where all values are byte arrays.
+A KEM combiner is a function that takes in two or more shared secrets `ss_i` and returns a combined shared secret `ss`, where all values are byte arrays.
 
 ~~~
-SS = kemCombiner(SS_1, SS_2, ..., SS_n)
+ss = kemCombiner(ss_1, ss_2, ..., ss_n)
 ~~~
 
 This document assumes that shared secrets are the output of a KEM, but without loss of generality they MAY also be any other source of cryptographic key material, such as pre-shared keys (PSKs), with PQ/PSK being a quantum-safe migration strategy being made available by some protocols, see for example IKEv2 in [RFC8784].
@@ -232,28 +232,29 @@ In general it is desirable to use a multi-PRF as a KEM combiner, a function that
 The following simple yet generic construction can be used in all IETF protocols that need to combine the output of two or more KEMs:
 
 ~~~
-KDF(counter || K_1 || ... || K_n || fixedInfo, outputBits)
+KDF(counter || k_1 || ... || k_n || fixedInfo, outputBits)
 ~~~
 {: title="general KEM combiner construction" }
 
 where:
 
 - `KDF` represents a suitable choice of cryptographic key derivation function,
-- `K_i` represent the constant-length input keys,
+- `k_i` represent the constant-length input keys,
 - `fixedInfo` is some protocol-specific KDF binding,
 - `counter` parameter is instantiation-specific and is discussed in {{sec-instantiation}}.
 - `outputBits` determines the length of the key,
 - `||` represents concatenation.
 
 In section {{sec-instantiation}} are listed several possible practical instantiations, in compliance with NIST SP-800 56Cr2 {{SP800-56C}}.
+The shared secret `ss` MAY be used as a Key Encryption Key (KEK) for key encapsulation.
 
-Each `K_i` MUST be constant in length, therefore the secret shares `SS_i` can be used directly only if they are guaranteed to be constant length. For all other cases, it is REQUIRED to hash them first:
+Each `k_i` MUST be constant in length, therefore the secret shares `ss_i` can be used directly only if they are guaranteed to be constant length. For all other cases, it is REQUIRED to hash them first:
 
 ~~~
-K_i = H(SS_i)
+k_i = H(ss_i)
 ~~~
 
-Any protocols making use of this construction MUST either hash all inputs `SS_i`, or justify that any un-hashed inputs will always be fixed length.
+Any protocols making use of this construction MUST either hash all inputs `ss_i`, or justify that any un-hashed inputs will always be fixed length.
 
 ## Protocol binding
 The `fixedInfo` string is a fixed-length string containing some context-specific information.
@@ -279,7 +280,7 @@ This is a non-comprehensive list, further information can be found in paragraph 
 # Practical instantiations {#sec-instantiation}
 
 The KDF MUST be instantiated with one of the following Keccak-based option.
-Each instance defines a function to be used as `KDF`, a hash `H` function to optionally derive the `K_i`, and a `counter`.
+Each instance defines a function to be used as `KDF`, a hash `H` function to optionally derive the `k_i`, and a `counter`.
 
 1. `KDF = SHA3-256` and `H = SHA3-256`, with `hashSize = 256 bit`.
 2. `KDF = SHA3-512` and `H = SHA3-512`, with `hashSize = 512 bit`.
@@ -288,21 +289,24 @@ Each instance defines a function to be used as `KDF`, a hash `H` function to opt
 
 ## Hash-and-counter based construction
 Options 1 and 2 instantiate the KDF using SHA3, specified in NIST FIPS 202 {{FIPS202}}.
-To generate an `outputBits` long secret share `SS`:
+To generate an `outputBits` long secret share `ss`:
 
 * the `counter` MUST be initialized with the string `0x00000001`.
 * The hash is performed over the string defined in {{sec-kem-combiner}}, and repeated `ceil(outputBits/hashSize)` times. For each iteration the `counter` MUST be increased by `0x01`.
 * The strings are concatenated ordered by `counter`.
-* The leftmost `outputBits` are returned as `SS`.
+* The leftmost `outputBits` are returned as `ss`.
 
 An implementation MUST NOT overflow and reuse the `counter` and an error MUST be returned when producing more than 2^32 consecutive hashes.
 
 ## KMAC based construction
 Options 3 and 4 are KMAC-based, as specified in NIST SP 800-185 {{SP800-185}}.
-The context `S` MUST be the utf-8 string "KDF", the key `K` MUST be a context-specific string of at least `hashSize` bits, and `counter` MUST be the fixed string `0x00000001`.
-The key `K` MAY be used as an additional option to perform context separation, in scenarios where `fixedInfo` is not sufficient.
+To instantiate the function:
 
-To derive a shared secret `SS` of desired length, KMAC is called a single time with the input string `X` defined in {{sec-kem-combiner}} and length `L` being `outputBits`.
+* The context `S` MUST be the utf-8 string "KDF".
+* The key `K` MUST be a context-specific string of at least `hashSize` bits, and it MAY be used as an additional option to perform context separation, in scenarios where `fixedInfo` is not sufficient.
+* The parameter `counter` MUST be the fixed string `0x00000001`.
+
+To derive a shared secret `ss` of desired length, KMAC is called a single time with the input string `X` defined in {{sec-kem-combiner}} and length `L` being `outputBits`.
 
 # IANA Considerations {#sec-iana}
 
@@ -313,7 +317,7 @@ None.
 The proposed instantiations in {{sec-instantiation}} are practical multi-PRFs and this specification limits to the use of Keccak-based constructions. The sponge construction was proven to be indifferentiable from a random oracle {{SPONGE}}.
 More precisely, for a given capacity `c` the indifferentiability proof shows that assuming there are no weaknesses found in the Keccak permutation, an attacker has to make an expected number of `2^(c/2)` calls to the permutation to tell Keccak from a random oracle.
 For a random oracle, a difference in only a single bit gives an unrelated, uniformly random output.
-Hence, to be able to distinguish a key `K`, derived from shared keys `K_i` from a random bit string, an adversary has to correctly guess all key shares `K_i` entirely.
+Hence, to be able to distinguish a key `k`, derived from shared keys `k_i` from a random bit string, an adversary has to correctly guess all key shares `k_i` entirely.
 
 <!-- Start of Appendices -->
 --- back

--- a/draft-ounsworth-cfrg-kem-combiners.mkd
+++ b/draft-ounsworth-cfrg-kem-combiners.mkd
@@ -184,7 +184,7 @@ The need for a KEM combiner function arises in three different contexts within I
 1. Post-quantum / traditional hybrid KEMs where output of a post-quantum KEM is combined with the output of a classical key transport or key exchange algorithm.
 1. KEM-based authenticated key exchanges (AKEs) where the output of two or more KEMs performed in different directions are combined.
 
-This document normalizes a mechanisms for combining the output of two or more KEMs.
+This document normalizes a mechanism for combining the output of two or more KEMs.
 
 ## KEM/PSK hybrids
 
@@ -228,7 +228,7 @@ ss = kemCombiner(ss_1, ss_2, ..., ss_n)
 
 This document assumes that shared secrets are the output of a KEM, but without loss of generality they MAY also be any other source of cryptographic key material, such as pre-shared keys (PSKs), with PQ/PSK being a quantum-safe migration strategy being made available by some protocols, see for example IKEv2 in [RFC8784].
 
-In general it is desirable to use a multi-PRF as a KEM combiner, a function that can be keyed by any input.
+In general it is desirable to use a multi-PRF as a KEM combiner, meaning a PRF when keyed by any of its single inputs.
 The following simple yet generic construction can be used in all IETF protocols that need to combine the output of two or more KEMs:
 
 ~~~
@@ -267,7 +267,8 @@ The parameter fixedInfo MAY contain any of the following information:
 
 * Public information about the communication parties, such as their identifiers.
 * The public keys or certificates contributed by each party to the key-agreement transaction.
-* Other public and/or private information shared between communication parties before or during the transaction, such as nonces or pre-shared secrets.
+* The ciphertext of each Key Encapsulation Mechanism.
+* Other public information shared between communication parties before or during the transaction, such as nonces.
 * An indication of the protocol or application employing the key-derivation method.
 * Protocol-related information, such as a label or session identifier.
 * An indication of the key-agreement scheme and/or key-derivation method used.
@@ -291,7 +292,7 @@ Each instance defines a function to be used as `KDF`, a hash `H` function to opt
 Options 1 and 2 instantiate the KDF using SHA3, specified in NIST FIPS 202 {{FIPS202}}.
 To generate an `outputBits` long secret share `ss`:
 
-* the `counter` MUST be initialized with the string `0x00000001`.
+* the `counter` MUST be initialized with the value `0x00000001`.
 * The hash is performed over the string defined in {{sec-kem-combiner}}, and repeated `ceil(outputBits/hashSize)` times. For each iteration the `counter` MUST be increased by `0x01`.
 * The strings are concatenated ordered by `counter`.
 * The leftmost `outputBits` are returned as `ss`.
@@ -304,9 +305,10 @@ To instantiate the function:
 
 * The context `S` MUST be the utf-8 string "KDF".
 * The key `K` MUST be a context-specific string of at least `hashSize` bits, and it MAY be used as an additional option to perform context separation, in scenarios where `fixedInfo` is not sufficient.
-* The parameter `counter` MUST be the fixed string `0x00000001`.
+* The parameter `counter` MUST be the fixed value `0x00000001`.
 
 To derive a shared secret `ss` of desired length, KMAC is called a single time with the input string `X` defined in {{sec-kem-combiner}} and length `L` being `outputBits`.
+This is compatible with the one-step KDF definition given in NIST SP800-56Cr2 {{SP800-56C}}, Section 4.
 
 # IANA Considerations {#sec-iana}
 

--- a/draft-ounsworth-cfrg-kem-combiners.txt
+++ b/draft-ounsworth-cfrg-kem-combiners.txt
@@ -5,8 +5,8 @@
 CFRG                                                        M. Ounsworth
 Internet-Draft                                                   Entrust
 Intended status: Informational                                A. Wussler
-Expires: 5 September 2023                                         Proton
-                                                            4 March 2023
+Expires: 8 September 2023                                         Proton
+                                                            7 March 2023
 
 
 Combiner function for hybrid key encapsulation mechanisms (Hybrid KEMs)
@@ -53,7 +53,7 @@ Status of This Memo
 
 
 
-Ounsworth & Wussler     Expires 5 September 2023                [Page 1]
+Ounsworth & Wussler     Expires 8 September 2023                [Page 1]
 
 Internet-Draft                KEM Combiner                    March 2023
 
@@ -63,7 +63,7 @@ Internet-Draft                KEM Combiner                    March 2023
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 5 September 2023.
+   This Internet-Draft will expire on 8 September 2023.
 
 Copyright Notice
 
@@ -90,12 +90,12 @@ Table of Contents
      4.1.  Hash-and-counter based construction . . . . . . . . . . .   7
      4.2.  KMAC based construction . . . . . . . . . . . . . . . . .   7
    5.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .   7
-   6.  Security Considerations . . . . . . . . . . . . . . . . . . .   7
+   6.  Security Considerations . . . . . . . . . . . . . . . . . . .   8
    7.  References  . . . . . . . . . . . . . . . . . . . . . . . . .   8
      7.1.  Normative References  . . . . . . . . . . . . . . . . . .   8
      7.2.  Informative References  . . . . . . . . . . . . . . . . .   8
    Acknowledgements  . . . . . . . . . . . . . . . . . . . . . . . .  10
-   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  10
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  11
 
 1.  Terminology
 
@@ -109,7 +109,7 @@ Table of Contents
 
 
 
-Ounsworth & Wussler     Expires 5 September 2023                [Page 2]
+Ounsworth & Wussler     Expires 8 September 2023                [Page 2]
 
 Internet-Draft                KEM Combiner                    March 2023
 
@@ -128,7 +128,7 @@ Internet-Draft                KEM Combiner                    March 2023
    def kemDecaps(ct, sk) -> ss
 
    where pk is public key, sk is secret key, ct is the ciphertext
-   repseresting an encapsulated key, and ss is shared secret.
+   representing an encapsulated key, and ss is shared secret.
 
    KEMs are typically used in cases where two parties, hereby refereed
    to as the "encapsulater" and the "decapsulater", wish to establish a
@@ -146,9 +146,9 @@ Internet-Draft                KEM Combiner                    March 2023
 
    2.  Post-quantum / traditional hybrid KEMs where output of a post-
        quantum KEM is combined with the output of a classical key
-       transport or key exchenge algorithm.
+       transport or key exchange algorithm.
 
-   3.  KEM-based authenticated key exchanges (AKEs) where the ouput of
+   3.  KEM-based authenticated key exchanges (AKEs) where the output of
        two or more KEMs performed in different directions are combined.
 
    This document normalizes a mechanisms for combining the output of two
@@ -165,7 +165,7 @@ Internet-Draft                KEM Combiner                    March 2023
 
 
 
-Ounsworth & Wussler     Expires 5 September 2023                [Page 3]
+Ounsworth & Wussler     Expires 8 September 2023                [Page 3]
 
 Internet-Draft                KEM Combiner                    March 2023
 
@@ -198,15 +198,15 @@ Internet-Draft                KEM Combiner                    March 2023
    particular this will arise for any protocol that needs to provide
    post-quantum replacements for static-static (Elliptic Curve) Diffie-
    Hellman mechanisms.  Examples include a KEM replacement for CMP's
-   DHBasedMac [I-D.ietf-lamps-cmp-updates], .. TODO: cite others.
+   DHBasedMac [I-D.ietf-lamps-cmp-updates].
 
 3.  KEM Combiner construction
 
    A KEM combiner is a function that takes in two or more shared secrets
-   SS_i and returns a combined shared secret SS, where all values are
+   ss_i and returns a combined shared secret ss, where all values are
    byte arrays.
 
-   SS = kemCombiner(SS_1, SS_2, ..., SS_n)
+   ss = kemCombiner(ss_1, ss_2, ..., ss_n)
 
    This document assumes that shared secrets are the output of a KEM,
    but without loss of generality they MAY also be any other source of
@@ -221,12 +221,12 @@ Internet-Draft                KEM Combiner                    March 2023
 
 
 
-Ounsworth & Wussler     Expires 5 September 2023                [Page 4]
+Ounsworth & Wussler     Expires 8 September 2023                [Page 4]
 
 Internet-Draft                KEM Combiner                    March 2023
 
 
-   KDF(counter || K_1 || ... || K_n || fixedInfo, outputBits)
+   KDF(counter || k_1 || ... || k_n || fixedInfo, outputBits)
 
                 Figure 1: general KEM combiner construction
 
@@ -235,7 +235,7 @@ Internet-Draft                KEM Combiner                    March 2023
    *  KDF represents a suitable choice of cryptographic key derivation
       function,
 
-   *  K_i represent the constant-length input keys,
+   *  k_i represent the constant-length input keys,
 
    *  fixedInfo is some protocol-specific KDF binding,
 
@@ -248,15 +248,17 @@ Internet-Draft                KEM Combiner                    March 2023
 
    In section Section 4 are listed several possible practical
    instantiations, in compliance with NIST SP-800 56Cr2 [SP800-56C].
+   The shared secret ss MAY be used as a Key Encryption Key (KEK) for
+   key encapsulation.
 
-   Each K_i MUST be constant in length, therefore the secret shares SS_i
+   Each k_i MUST be constant in length, therefore the secret shares ss_i
    can be used directly only if they are guaranteed to be constant
    length.  For all other cases, it is REQUIRED to hash them first:
 
-   K_i = H(SS_i)
+   k_i = H(ss_i)
 
    Any protocols making use of this construction MUST either hash all
-   inputs SS_i, or justify that any un-hashed inputs will always be
+   inputs ss_i, or justify that any un-hashed inputs will always be
    fixed length.
 
 3.1.  Protocol binding
@@ -273,14 +275,14 @@ Internet-Draft                KEM Combiner                    March 2023
    the representation of a public key or an OID, then hashing or padding
    can be used.
 
-   The parameter fixedInfo MAY contain any of the following information:
 
 
-
-Ounsworth & Wussler     Expires 5 September 2023                [Page 5]
+Ounsworth & Wussler     Expires 8 September 2023                [Page 5]
 
 Internet-Draft                KEM Combiner                    March 2023
 
+
+   The parameter fixedInfo MAY contain any of the following information:
 
    *  Public information about the communication parties, such as their
       identifiers.
@@ -317,7 +319,7 @@ Internet-Draft                KEM Combiner                    March 2023
 
    The KDF MUST be instantiated with one of the following Keccak-based
    option.  Each instance defines a function to be used as KDF, a hash H
-   function to optionally derive the K_i, and a counter.
+   function to optionally derive the k_i, and a counter.
 
    1.  KDF = SHA3-256 and H = SHA3-256, with hashSize = 256 bit.
 
@@ -331,9 +333,7 @@ Internet-Draft                KEM Combiner                    March 2023
 
 
 
-
-
-Ounsworth & Wussler     Expires 5 September 2023                [Page 6]
+Ounsworth & Wussler     Expires 8 September 2023                [Page 6]
 
 Internet-Draft                KEM Combiner                    March 2023
 
@@ -341,7 +341,7 @@ Internet-Draft                KEM Combiner                    March 2023
 4.1.  Hash-and-counter based construction
 
    Options 1 and 2 instantiate the KDF using SHA3, specified in NIST
-   FIPS 202 [FIPS202].  To generate an outputBits long secret share SS:
+   FIPS 202 [FIPS202].  To generate an outputBits long secret share ss:
 
    *  the counter MUST be initialized with the string 0x00000001.
 
@@ -351,7 +351,7 @@ Internet-Draft                KEM Combiner                    March 2023
 
    *  The strings are concatenated ordered by counter.
 
-   *  The leftmost outputBits are returned as SS.
+   *  The leftmost outputBits are returned as ss.
 
    An implementation MUST NOT overflow and reuse the counter and an
    error MUST be returned when producing more than 2^32 consecutive
@@ -360,19 +360,39 @@ Internet-Draft                KEM Combiner                    March 2023
 4.2.  KMAC based construction
 
    Options 3 and 4 are KMAC-based, as specified in NIST SP 800-185
-   [SP800-185].  The context S MUST be the utf-8 string "KDF", the key K
-   MUST be a context-specific string of at least hashSize bits, and
-   counter MUST be the fixed string 0x00000001.  The key K MAY be used
-   as an additional option to perform context separation, in scenarios
-   where fixedInfo is not sufficient.
+   [SP800-185].  To instantiate the function:
 
-   To derive a shared secret SS of desired length, KMAC is called a
+   *  The context S MUST be the utf-8 string "KDF".
+
+   *  The key K MUST be a context-specific string of at least hashSize
+      bits, and it MAY be used as an additional option to perform
+      context separation, in scenarios where fixedInfo is not
+      sufficient.
+
+   *  The parameter counter MUST be the fixed string 0x00000001.
+
+   To derive a shared secret ss of desired length, KMAC is called a
    single time with the input string X defined in Section 3 and length L
    being outputBits.
 
 5.  IANA Considerations
 
    None.
+
+
+
+
+
+
+
+
+
+
+
+Ounsworth & Wussler     Expires 8 September 2023                [Page 7]
+
+Internet-Draft                KEM Combiner                    March 2023
+
 
 6.  Security Considerations
 
@@ -385,16 +405,8 @@ Internet-Draft                KEM Combiner                    March 2023
    number of 2^(c/2) calls to the permutation to tell Keccak from a
    random oracle.  For a random oracle, a difference in only a single
    bit gives an unrelated, uniformly random output.  Hence, to be able
-   to distinguish a key K, derived from shared keys K_i from a random
-
-
-
-Ounsworth & Wussler     Expires 5 September 2023                [Page 7]
-
-Internet-Draft                KEM Combiner                    March 2023
-
-
-   bit string, an adversary has to correctly guess all key shares K_i
+   to distinguish a key k, derived from shared keys k_i from a random
+   bit string, an adversary has to correctly guess all key shares k_i
    entirely.
 
 7.  References
@@ -428,6 +440,16 @@ Internet-Draft                KEM Combiner                    March 2023
               <https://datatracker.ietf.org/doc/html/draft-ietf-ipsecme-
               ikev2-multiple-ke-12>.
 
+
+
+
+
+
+Ounsworth & Wussler     Expires 8 September 2023                [Page 8]
+
+Internet-Draft                KEM Combiner                    March 2023
+
+
    [I-D.ietf-lamps-cmp-updates]
               Brockhaus, H., von Oheimb, D., and J. Gray, "Certificate
               Management Protocol (CMP) Updates", Work in Progress,
@@ -441,14 +463,6 @@ Internet-Draft                KEM Combiner                    March 2023
               draft-ietf-tls-hybrid-design-06, 27 February 2023,
               <https://datatracker.ietf.org/doc/html/draft-ietf-tls-
               hybrid-design-06>.
-
-
-
-
-Ounsworth & Wussler     Expires 5 September 2023                [Page 8]
-
-Internet-Draft                KEM Combiner                    March 2023
-
 
    [I-D.ounsworth-pq-composite-kem]
               Ounsworth, M. and J. Gray, "Composite KEM For Use In
@@ -482,6 +496,16 @@ Internet-Draft                KEM Combiner                    March 2023
               DOI 10.17487/RFC8696, December 2019,
               <https://www.rfc-editor.org/info/rfc8696>.
 
+
+
+
+
+
+Ounsworth & Wussler     Expires 8 September 2023                [Page 9]
+
+Internet-Draft                KEM Combiner                    March 2023
+
+
    [RFC8784]  Fluhrer, S., Kampanakis, P., McGrew, D., and V. Smyslov,
               "Mixing Preshared Keys in the Internet Key Exchange
               Protocol Version 2 (IKEv2) for Post-quantum Security",
@@ -493,18 +517,6 @@ Internet-Draft                KEM Combiner                    March 2023
               Functions: cSHAKE, KMAC, TupleHash, and ParallelHash",
               NIST Special Publication 800-185 , 2016,
               <https://doi.org/10.6028/NIST.SP.800-185>.
-
-
-
-
-
-
-
-
-Ounsworth & Wussler     Expires 5 September 2023                [Page 9]
-
-Internet-Draft                KEM Combiner                    March 2023
-
 
    [SP800-56A]
               Barker, E., Chen, L., Roginsky, A., Vassilev, A., and R.
@@ -543,6 +555,13 @@ Acknowledgements
    "Copying always makes things easier and less error prone" -
    [RFC8411].
 
+
+
+Ounsworth & Wussler     Expires 8 September 2023               [Page 10]
+
+Internet-Draft                KEM Combiner                    March 2023
+
+
 Authors' Addresses
 
    Mike Ounsworth
@@ -551,15 +570,6 @@ Authors' Addresses
    Ottawa, Ontario  K2K 3G5
    Canada
    Email: mike.ounsworth@entrust.com
-
-
-
-
-
-
-Ounsworth & Wussler     Expires 5 September 2023               [Page 10]
-
-Internet-Draft                KEM Combiner                    March 2023
 
 
    Aron Wussler
@@ -603,14 +613,4 @@ Internet-Draft                KEM Combiner                    March 2023
 
 
 
-
-
-
-
-
-
-
-
-
-
-Ounsworth & Wussler     Expires 5 September 2023               [Page 11]
+Ounsworth & Wussler     Expires 8 September 2023               [Page 11]

--- a/draft-ounsworth-cfrg-kem-combiners.txt
+++ b/draft-ounsworth-cfrg-kem-combiners.txt
@@ -5,8 +5,8 @@
 CFRG                                                        M. Ounsworth
 Internet-Draft                                                   Entrust
 Intended status: Informational                                A. Wussler
-Expires: 8 September 2023                                         Proton
-                                                            7 March 2023
+Expires: 9 September 2023                                         Proton
+                                                            8 March 2023
 
 
 Combiner function for hybrid key encapsulation mechanisms (Hybrid KEMs)
@@ -53,7 +53,7 @@ Status of This Memo
 
 
 
-Ounsworth & Wussler     Expires 8 September 2023                [Page 1]
+Ounsworth & Wussler     Expires 9 September 2023                [Page 1]
 
 Internet-Draft                KEM Combiner                    March 2023
 
@@ -63,7 +63,7 @@ Internet-Draft                KEM Combiner                    March 2023
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 8 September 2023.
+   This Internet-Draft will expire on 9 September 2023.
 
 Copyright Notice
 
@@ -109,7 +109,7 @@ Table of Contents
 
 
 
-Ounsworth & Wussler     Expires 8 September 2023                [Page 2]
+Ounsworth & Wussler     Expires 9 September 2023                [Page 2]
 
 Internet-Draft                KEM Combiner                    March 2023
 
@@ -151,7 +151,7 @@ Internet-Draft                KEM Combiner                    March 2023
    3.  KEM-based authenticated key exchanges (AKEs) where the output of
        two or more KEMs performed in different directions are combined.
 
-   This document normalizes a mechanisms for combining the output of two
+   This document normalizes a mechanism for combining the output of two
    or more KEMs.
 
 2.1.  KEM/PSK hybrids
@@ -165,7 +165,7 @@ Internet-Draft                KEM Combiner                    March 2023
 
 
 
-Ounsworth & Wussler     Expires 8 September 2023                [Page 3]
+Ounsworth & Wussler     Expires 9 September 2023                [Page 3]
 
 Internet-Draft                KEM Combiner                    March 2023
 
@@ -214,14 +214,14 @@ Internet-Draft                KEM Combiner                    March 2023
    PSK being a quantum-safe migration strategy being made available by
    some protocols, see for example IKEv2 in [RFC8784].
 
-   In general it is desirable to use a multi-PRF as a KEM combiner, a
-   function that can be keyed by any input.  The following simple yet
-   generic construction can be used in all IETF protocols that need to
-   combine the output of two or more KEMs:
+   In general it is desirable to use a multi-PRF as a KEM combiner,
+   meaning a PRF when keyed by any of its single inputs.  The following
+   simple yet generic construction can be used in all IETF protocols
+   that need to combine the output of two or more KEMs:
 
 
 
-Ounsworth & Wussler     Expires 8 September 2023                [Page 4]
+Ounsworth & Wussler     Expires 9 September 2023                [Page 4]
 
 Internet-Draft                KEM Combiner                    March 2023
 
@@ -277,7 +277,7 @@ Internet-Draft                KEM Combiner                    March 2023
 
 
 
-Ounsworth & Wussler     Expires 8 September 2023                [Page 5]
+Ounsworth & Wussler     Expires 9 September 2023                [Page 5]
 
 Internet-Draft                KEM Combiner                    March 2023
 
@@ -290,9 +290,10 @@ Internet-Draft                KEM Combiner                    March 2023
    *  The public keys or certificates contributed by each party to the
       key-agreement transaction.
 
-   *  Other public and/or private information shared between
-      communication parties before or during the transaction, such as
-      nonces or pre-shared secrets.
+   *  The ciphertext of each Key Encapsulation Mechanism.
+
+   *  Other public information shared between communication parties
+      before or during the transaction, such as nonces.
 
    *  An indication of the protocol or application employing the key-
       derivation method.
@@ -332,8 +333,7 @@ Internet-Draft                KEM Combiner                    March 2023
 
 
 
-
-Ounsworth & Wussler     Expires 8 September 2023                [Page 6]
+Ounsworth & Wussler     Expires 9 September 2023                [Page 6]
 
 Internet-Draft                KEM Combiner                    March 2023
 
@@ -343,7 +343,7 @@ Internet-Draft                KEM Combiner                    March 2023
    Options 1 and 2 instantiate the KDF using SHA3, specified in NIST
    FIPS 202 [FIPS202].  To generate an outputBits long secret share ss:
 
-   *  the counter MUST be initialized with the string 0x00000001.
+   *  the counter MUST be initialized with the value 0x00000001.
 
    *  The hash is performed over the string defined in Section 3, and
       repeated ceil(outputBits/hashSize) times.  For each iteration the
@@ -369,11 +369,12 @@ Internet-Draft                KEM Combiner                    March 2023
       context separation, in scenarios where fixedInfo is not
       sufficient.
 
-   *  The parameter counter MUST be the fixed string 0x00000001.
+   *  The parameter counter MUST be the fixed value 0x00000001.
 
    To derive a shared secret ss of desired length, KMAC is called a
    single time with the input string X defined in Section 3 and length L
-   being outputBits.
+   being outputBits.  This is compatible with the one-step KDF
+   definition given in NIST SP800-56Cr2 [SP800-56C], Section 4.
 
 5.  IANA Considerations
 
@@ -388,8 +389,7 @@ Internet-Draft                KEM Combiner                    March 2023
 
 
 
-
-Ounsworth & Wussler     Expires 8 September 2023                [Page 7]
+Ounsworth & Wussler     Expires 9 September 2023                [Page 7]
 
 Internet-Draft                KEM Combiner                    March 2023
 
@@ -445,7 +445,7 @@ Internet-Draft                KEM Combiner                    March 2023
 
 
 
-Ounsworth & Wussler     Expires 8 September 2023                [Page 8]
+Ounsworth & Wussler     Expires 9 September 2023                [Page 8]
 
 Internet-Draft                KEM Combiner                    March 2023
 
@@ -501,7 +501,7 @@ Internet-Draft                KEM Combiner                    March 2023
 
 
 
-Ounsworth & Wussler     Expires 8 September 2023                [Page 9]
+Ounsworth & Wussler     Expires 9 September 2023                [Page 9]
 
 Internet-Draft                KEM Combiner                    March 2023
 
@@ -557,7 +557,7 @@ Acknowledgements
 
 
 
-Ounsworth & Wussler     Expires 8 September 2023               [Page 10]
+Ounsworth & Wussler     Expires 9 September 2023               [Page 10]
 
 Internet-Draft                KEM Combiner                    March 2023
 
@@ -613,4 +613,4 @@ Authors' Addresses
 
 
 
-Ounsworth & Wussler     Expires 8 September 2023               [Page 11]
+Ounsworth & Wussler     Expires 9 September 2023               [Page 11]


### PR DESCRIPTION
- Change capitalization of variables
- Allow `ss` to be used as KEK
- Fix formatting
- Fix typos

I think in this draft we are defining a key combiner + key derivation function, not just a key combiner, and this should be reflected better than just a sentence. Any idea?