### PR TITLE
Change construction to include ciphertexts

### DIFF
--- a/draft-ounsworth-cfrg-kem-combiners.html
+++ b/draft-ounsworth-cfrg-kem-combiners.html
@@ -1181,7 +1181,7 @@ li > p:last-of-type {
 </tr></thead>
 <tfoot><tr>
 <td class="left">Ounsworth &amp; Wussler</td>
-<td class="center">Expires 9 September 2023</td>
+<td class="center">Expires 10 September 2023</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -1194,12 +1194,12 @@ li > p:last-of-type {
 <dd class="internet-draft">draft-ounsworth-cfrg-kem-combiners-00</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2023-03-08" class="published">8 March 2023</time>
+<time datetime="2023-03-09" class="published">9 March 2023</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Informational</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2023-09-09">9 September 2023</time></dd>
+<dd class="expires"><time datetime="2023-09-10">10 September 2023</time></dd>
 <dt class="label-authors">Authors:</dt>
 <dd class="authors">
 <div class="author">
@@ -1253,7 +1253,7 @@ li > p:last-of-type {
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on 9 September 2023.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on 10 September 2023.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">
@@ -1338,10 +1338,13 @@ li > p:last-of-type {
             </ul>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8">
-            <p id="section-toc.1-1.8.1"><a href="#appendix-A" class="xref"></a><a href="#name-acknowledgements-2" class="xref">Acknowledgements</a></p>
+            <p id="section-toc.1-1.8.1"><a href="#appendix-A" class="xref"></a><a href="#name-contributors-2" class="xref">Contributors</a></p>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.9">
-            <p id="section-toc.1-1.9.1"><a href="#appendix-B" class="xref"></a><a href="#name-authors-addresses-2" class="xref">Authors' Addresses</a></p>
+            <p id="section-toc.1-1.9.1"><a href="#appendix-B" class="xref"></a><a href="#name-acknowledgements-2" class="xref">Acknowledgements</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.10">
+            <p id="section-toc.1-1.10.1"><a href="#appendix-C" class="xref"></a><a href="#name-authors-addresses-2" class="xref">Authors' Addresses</a></p>
 </li>
         </ul>
 </nav>
@@ -1451,7 +1454,7 @@ KDF(counter || k_1 || ... || k_n || fixedInfo, outputBits)
           <code>KDF</code> represents a suitable choice of cryptographic key derivation function,<a href="#section-3-7.1" class="pilcrow">¶</a>
 </li>
         <li class="normal" id="section-3-7.2">
-          <code>k_i</code> represent the constant-length input keys,<a href="#section-3-7.2" class="pilcrow">¶</a>
+          <code>k_i</code> represent the i-th constant-length input key,<a href="#section-3-7.2" class="pilcrow">¶</a>
 </li>
         <li class="normal" id="section-3-7.3">
           <code>fixedInfo</code> is some protocol-specific KDF binding,<a href="#section-3-7.3" class="pilcrow">¶</a>
@@ -1468,43 +1471,49 @@ KDF(counter || k_1 || ... || k_n || fixedInfo, outputBits)
       </ul>
 <p id="section-3-8">In section <a href="#sec-instantiation" class="xref">Section 4</a> are listed several possible practical instantiations, in compliance with NIST SP-800 56Cr2 <span>[<a href="#SP800-56C" class="xref">SP800-56C</a>]</span>.
 The shared secret <code>ss</code> MAY be used as a Key Encryption Key (KEK) for key encapsulation.<a href="#section-3-8" class="pilcrow">¶</a></p>
-<p id="section-3-9">Each <code>k_i</code> MUST be constant in length, therefore the secret shares <code>ss_i</code> can be used directly only if they are guaranteed to be constant length. For all other cases, it is REQUIRED to hash them first:<a href="#section-3-9" class="pilcrow">¶</a></p>
+<p id="section-3-9">Each <code>k_i</code> MUST be constant in length, therefore it is the concatenation of the secret share <code>ss_i</code> and ciphertext <code>ct_i</code> only if they are guaranteed to be constant length:<a href="#section-3-9" class="pilcrow">¶</a></p>
 <div class="alignLeft art-text artwork" id="section-3-10">
 <pre>
-k_i = H(ss_i)
+k_i = ss_i || ct_i
 </pre><a href="#section-3-10" class="pilcrow">¶</a>
 </div>
-<p id="section-3-11">Any protocols making use of this construction MUST either hash all inputs <code>ss_i</code>, or justify that any un-hashed inputs will always be fixed length.<a href="#section-3-11" class="pilcrow">¶</a></p>
+<p id="section-3-11">For all other cases, it is REQUIRED to concatenate and hash them first:<a href="#section-3-11" class="pilcrow">¶</a></p>
+<div class="alignLeft art-text artwork" id="section-3-12">
+<pre>
+k_i = H(ss_i || ct_i)
+</pre><a href="#section-3-12" class="pilcrow">¶</a>
+</div>
+<p id="section-3-13">Any protocols making use of this construction MUST either hash all inputs <code>ss_i || ct_i</code>, or justify that any un-hashed inputs will always be fixed length.<a href="#section-3-13" class="pilcrow">¶</a></p>
+<p id="section-3-14">Including the ciphertext guarantees that the combined kem is IND-CCA secure as long as one of the ingredient KEMs is, as stated by <span>[<a href="#KEMCombiners" class="xref">KEMCombiners</a>]</span>.<a href="#section-3-14" class="pilcrow">¶</a></p>
 <div id="protocol-binding">
 <section id="section-3.1">
         <h3 id="name-protocol-binding-2">
 <a href="#section-3.1" class="section-number selfRef">3.1. </a><a href="#name-protocol-binding-2" class="section-name selfRef">Protocol binding</a>
         </h3>
 <p id="section-3.1-1">The <code>fixedInfo</code> string is a fixed-length string containing some context-specific information.
-It MUST NOT depend on the secret shares. The intention is to prevent cross-protocol attacks by making this key derivation unique to its protocol context.<a href="#section-3.1-1" class="pilcrow">¶</a></p>
+The intention is to prevent cross-context attacks by making this key derivation unique to its protocol context.<a href="#section-3.1-1" class="pilcrow">¶</a></p>
 <p id="section-3.1-2">The <code>fixedInfo</code> string MUST have a definite structure depending on the protocol where all parts are fixed length. This prevents a variable length structure from creating collisions between two different instances.
-In cases some variable length input is necessary, such as the representation of a public key or an OID, then hashing or padding can be used.<a href="#section-3.1-2" class="pilcrow">¶</a></p>
+In cases some variable length input is necessary, such as the representation of a public key or an OID, then hashing or padding can be used.
+<code>fixedInfo</code> MUST NOT include the shared secrets and ciphertexts, as they are already represented in the KDF input.<a href="#section-3.1-2" class="pilcrow">¶</a></p>
 <p id="section-3.1-3">The parameter fixedInfo MAY contain any of the following information:<a href="#section-3.1-3" class="pilcrow">¶</a></p>
 <ul class="normal">
 <li class="normal" id="section-3.1-4.1">Public information about the communication parties, such as their identifiers.<a href="#section-3.1-4.1" class="pilcrow">¶</a>
 </li>
           <li class="normal" id="section-3.1-4.2">The public keys or certificates contributed by each party to the key-agreement transaction.<a href="#section-3.1-4.2" class="pilcrow">¶</a>
 </li>
-          <li class="normal" id="section-3.1-4.3">The ciphertext of each Key Encapsulation Mechanism.<a href="#section-3.1-4.3" class="pilcrow">¶</a>
+          <li class="normal" id="section-3.1-4.3">Other public information shared between communication parties before or during the transaction, such as nonces.<a href="#section-3.1-4.3" class="pilcrow">¶</a>
 </li>
-          <li class="normal" id="section-3.1-4.4">Other public information shared between communication parties before or during the transaction, such as nonces.<a href="#section-3.1-4.4" class="pilcrow">¶</a>
+          <li class="normal" id="section-3.1-4.4">An indication of the protocol or application employing the key-derivation method.<a href="#section-3.1-4.4" class="pilcrow">¶</a>
 </li>
-          <li class="normal" id="section-3.1-4.5">An indication of the protocol or application employing the key-derivation method.<a href="#section-3.1-4.5" class="pilcrow">¶</a>
+          <li class="normal" id="section-3.1-4.5">Protocol-related information, such as a label or session identifier.<a href="#section-3.1-4.5" class="pilcrow">¶</a>
 </li>
-          <li class="normal" id="section-3.1-4.6">Protocol-related information, such as a label or session identifier.<a href="#section-3.1-4.6" class="pilcrow">¶</a>
+          <li class="normal" id="section-3.1-4.6">An indication of the key-agreement scheme and/or key-derivation method used.<a href="#section-3.1-4.6" class="pilcrow">¶</a>
 </li>
-          <li class="normal" id="section-3.1-4.7">An indication of the key-agreement scheme and/or key-derivation method used.<a href="#section-3.1-4.7" class="pilcrow">¶</a>
+          <li class="normal" id="section-3.1-4.7">An indication of the domain parameters associated with the asymmetric key pairs employed for key establishment.<a href="#section-3.1-4.7" class="pilcrow">¶</a>
 </li>
-          <li class="normal" id="section-3.1-4.8">An indication of the domain parameters associated with the asymmetric key pairs employed for key establishment.<a href="#section-3.1-4.8" class="pilcrow">¶</a>
+          <li class="normal" id="section-3.1-4.8">An indication of other parameter or primitive choices.<a href="#section-3.1-4.8" class="pilcrow">¶</a>
 </li>
-          <li class="normal" id="section-3.1-4.9">An indication of other parameter or primitive choices.<a href="#section-3.1-4.9" class="pilcrow">¶</a>
-</li>
-          <li class="normal" id="section-3.1-4.10">An indication of how the derived keying material should be parsed, including an indication of which algorithm(s) will use the (parsed) keying material.<a href="#section-3.1-4.10" class="pilcrow">¶</a>
+          <li class="normal" id="section-3.1-4.9">An indication of how the derived keying material should be parsed, including an indication of which algorithm(s) will use the (parsed) keying material.<a href="#section-3.1-4.9" class="pilcrow">¶</a>
 </li>
         </ul>
 <p id="section-3.1-5">This is a non-comprehensive list, further information can be found in paragraph 5.8.2 of NIST SP800-56Ar3 <span>[<a href="#SP800-56A" class="xref">SP800-56A</a>]</span>.<a href="#section-3.1-5" class="pilcrow">¶</a></p>
@@ -1641,6 +1650,10 @@ Hence, to be able to distinguish a key <code>k</code>, derived from shared keys 
         <dd>
 <span class="refAuthor">Kousidis, S.</span>, <span class="refAuthor">Strenzke, F.</span>, and <span class="refAuthor">A. Wussler</span>, <span class="refTitle">"Post-Quantum Cryptography in OpenPGP"</span>, <span class="refContent">Work in Progress</span>, <span class="seriesInfo">Internet-Draft, draft-wussler-openpgp-pqc-00</span>, <time datetime="2022-12-21" class="refDate">21 December 2022</time>, <span>&lt;<a href="https://datatracker.ietf.org/doc/html/draft-wussler-openpgp-pqc-00">https://datatracker.ietf.org/doc/html/draft-wussler-openpgp-pqc-00</a>&gt;</span>. </dd>
 <dd class="break"></dd>
+<dt id="KEMCombiners">[KEMCombiners]</dt>
+        <dd>
+<span class="refAuthor">Giacon, F.</span>, <span class="refAuthor">Heuer, F.</span>, and <span class="refAuthor">B. Poettering</span>, <span class="refTitle">"KEM Combiners"</span>, <time datetime="2018" class="refDate">2018</time>, <span>&lt;<a href="https://eprint.iacr.org/2018/024">https://eprint.iacr.org/2018/024</a>&gt;</span>. </dd>
+<dd class="break"></dd>
 <dt id="PQCAPI">[PQCAPI]</dt>
         <dd>
 <span class="refAuthor">Project, N. P.-Q. C.</span>, <span class="refTitle">"PQC - API notes"</span>, <time datetime="2022-11" class="refDate">November 2022</time>, <span>&lt;<a href="https://csrc.nist.gov/CSRC/media/Projects/Post-Quantum-Cryptography/documents/example-files/api-notes.pdf">https://csrc.nist.gov/CSRC/media/Projects/Post-Quantum-Cryptography/documents/example-files/api-notes.pdf</a>&gt;</span>. </dd>
@@ -1680,21 +1693,29 @@ Hence, to be able to distinguish a key <code>k</code>, derived from shared keys 
 </dl>
 </section>
 </section>
-<div id="acknowledgements">
+<div id="contributors">
 <section id="appendix-A">
+      <h2 id="name-contributors-2">
+<a href="#name-contributors-2" class="section-name selfRef">Contributors</a>
+      </h2>
+<p id="appendix-A-1">Stavros Kousidis (BSI)<a href="#appendix-A-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="acknowledgements">
+<section id="appendix-B">
       <h2 id="name-acknowledgements-2">
 <a href="#name-acknowledgements-2" class="section-name selfRef">Acknowledgements</a>
       </h2>
-<p id="appendix-A-1">This document incorporates contributions and comments from a large group of experts. The authors would especially like to acknowledge the expertise and tireless dedication of the following people, who attended many long meetings and generated millions of bytes of electronic mail and VOIP traffic over the past years in pursuit of this document:<a href="#appendix-A-1" class="pilcrow">¶</a></p>
-<p id="appendix-A-2">Douglas Stebila, Nimrod Aviram, Andreas Huelsing, and Stavros Kousidis.<a href="#appendix-A-2" class="pilcrow">¶</a></p>
-<p id="appendix-A-3">We are grateful to all, including any contributors who may have
-been inadvertently omitted from this list.<a href="#appendix-A-3" class="pilcrow">¶</a></p>
-<p id="appendix-A-4">This document borrows text from similar documents, including those referenced below. Thanks go to the authors of those
-   documents.  "Copying always makes things easier and less error prone" - <span>[<a href="#RFC8411" class="xref">RFC8411</a>]</span>.<a href="#appendix-A-4" class="pilcrow">¶</a></p>
+<p id="appendix-B-1">This document incorporates contributions and comments from a large group of experts. The authors would especially like to acknowledge the expertise and tireless dedication of the following people, who attended many long meetings and generated millions of bytes of electronic mail and VOIP traffic over the past years in pursuit of this document:<a href="#appendix-B-1" class="pilcrow">¶</a></p>
+<p id="appendix-B-2">Douglas Stebila, Nimrod Aviram, and Andreas Huelsing.<a href="#appendix-B-2" class="pilcrow">¶</a></p>
+<p id="appendix-B-3">We are grateful to all, including any contributors who may have
+been inadvertently omitted from this list.<a href="#appendix-B-3" class="pilcrow">¶</a></p>
+<p id="appendix-B-4">This document borrows text from similar documents, including those referenced below. Thanks go to the authors of those
+   documents.  "Copying always makes things easier and less error prone" - <span>[<a href="#RFC8411" class="xref">RFC8411</a>]</span>.<a href="#appendix-B-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="authors-addresses">
-<section id="appendix-B">
+<section id="appendix-C">
       <h2 id="name-authors-addresses-2">
 <a href="#name-authors-addresses-2" class="section-name selfRef">Authors' Addresses</a>
       </h2>

--- a/draft-ounsworth-cfrg-kem-combiners.mkd
+++ b/draft-ounsworth-cfrg-kem-combiners.mkd
@@ -128,7 +128,7 @@ informative:
     seriesinfo:
       Federal information Processing Standards Publication (FIPS) 202
   SPONGE:
-    target: https://keccak.team/files/CSF-0.1.pdf
+    target: "https://keccak.team/files/CSF-0.1.pdf"
     title: Cryptographic sponge functions
     author:
       -
@@ -144,6 +144,20 @@ informative:
         ins: G. Assche
         name: Gilles van Assche
     date: January 2011
+  KEMCombiners:
+    target: "https://eprint.iacr.org/2018/024"
+    title: KEM Combiners
+    author:
+      -
+        ins: F. Giacon
+        name: Federico Giacon
+      -
+        ins: F. Heuer
+        name: Felix Heuer
+      -
+        ins: B. Poettering
+        name: Bertram Poettering
+    date: 2018
 
 --- abstract
 
@@ -239,7 +253,7 @@ KDF(counter || k_1 || ... || k_n || fixedInfo, outputBits)
 where:
 
 - `KDF` represents a suitable choice of cryptographic key derivation function,
-- `k_i` represent the constant-length input keys,
+- `k_i` represent the i-th constant-length input key,
 - `fixedInfo` is some protocol-specific KDF binding,
 - `counter` parameter is instantiation-specific and is discussed in {{sec-instantiation}}.
 - `outputBits` determines the length of the key,
@@ -248,26 +262,34 @@ where:
 In section {{sec-instantiation}} are listed several possible practical instantiations, in compliance with NIST SP-800 56Cr2 {{SP800-56C}}.
 The shared secret `ss` MAY be used as a Key Encryption Key (KEK) for key encapsulation.
 
-Each `k_i` MUST be constant in length, therefore the secret shares `ss_i` can be used directly only if they are guaranteed to be constant length. For all other cases, it is REQUIRED to hash them first:
+Each `k_i` MUST be constant in length, therefore it is the concatenation of the secret share `ss_i` and ciphertext `ct_i` only if they are guaranteed to be constant length:
 
 ~~~
-k_i = H(ss_i)
+k_i = ss_i || ct_i
 ~~~
 
-Any protocols making use of this construction MUST either hash all inputs `ss_i`, or justify that any un-hashed inputs will always be fixed length.
+For all other cases, it is REQUIRED to concatenate and hash them first:
+
+~~~
+k_i = H(ss_i || ct_i)
+~~~
+
+Any protocols making use of this construction MUST either hash all inputs `ss_i || ct_i`, or justify that any un-hashed inputs will always be fixed length.
+
+Including the ciphertext guarantees that the combined kem is IND-CCA secure as long as one of the ingredient KEMs is, as stated by {{KEMCombiners}}.
 
 ## Protocol binding
 The `fixedInfo` string is a fixed-length string containing some context-specific information.
-It MUST NOT depend on the secret shares. The intention is to prevent cross-protocol attacks by making this key derivation unique to its protocol context.
+The intention is to prevent cross-context attacks by making this key derivation unique to its protocol context.
 
 The `fixedInfo` string MUST have a definite structure depending on the protocol where all parts are fixed length. This prevents a variable length structure from creating collisions between two different instances.
 In cases some variable length input is necessary, such as the representation of a public key or an OID, then hashing or padding can be used.
+`fixedInfo` MUST NOT include the shared secrets and ciphertexts, as they are already represented in the KDF input.
 
 The parameter fixedInfo MAY contain any of the following information:
 
 * Public information about the communication parties, such as their identifiers.
 * The public keys or certificates contributed by each party to the key-agreement transaction.
-* The ciphertext of each Key Encapsulation Mechanism.
 * Other public information shared between communication parties before or during the transaction, such as nonces.
 * An indication of the protocol or application employing the key-derivation method.
 * Protocol-related information, such as a label or session identifier.
@@ -324,12 +346,17 @@ Hence, to be able to distinguish a key `k`, derived from shared keys `k_i` from 
 <!-- Start of Appendices -->
 --- back
 
+# Contributors
+{:numbered="false"}
+
+Stavros Kousidis (BSI)
+
 # Acknowledgements
 {:numbered="false"}
 
 This document incorporates contributions and comments from a large group of experts. The authors would especially like to acknowledge the expertise and tireless dedication of the following people, who attended many long meetings and generated millions of bytes of electronic mail and VOIP traffic over the past years in pursuit of this document:
 
-Douglas Stebila, Nimrod Aviram, Andreas Huelsing, and Stavros Kousidis.
+Douglas Stebila, Nimrod Aviram, and Andreas Huelsing.
 
 We are grateful to all, including any contributors who may have
 been inadvertently omitted from this list.

--- a/draft-ounsworth-cfrg-kem-combiners.txt
+++ b/draft-ounsworth-cfrg-kem-combiners.txt
@@ -5,8 +5,8 @@
 CFRG                                                        M. Ounsworth
 Internet-Draft                                                   Entrust
 Intended status: Informational                                A. Wussler
-Expires: 9 September 2023                                         Proton
-                                                            8 March 2023
+Expires: 10 September 2023                                        Proton
+                                                            9 March 2023
 
 
 Combiner function for hybrid key encapsulation mechanisms (Hybrid KEMs)
@@ -53,7 +53,7 @@ Status of This Memo
 
 
 
-Ounsworth & Wussler     Expires 9 September 2023                [Page 1]
+Ounsworth & Wussler     Expires 10 September 2023               [Page 1]
 
 Internet-Draft                KEM Combiner                    March 2023
 
@@ -63,7 +63,7 @@ Internet-Draft                KEM Combiner                    March 2023
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 9 September 2023.
+   This Internet-Draft will expire on 10 September 2023.
 
 Copyright Notice
 
@@ -85,16 +85,17 @@ Table of Contents
      2.2.  PQ/Traditional hybrid KEMs  . . . . . . . . . . . . . . .   4
      2.3.  KEM-based AKE . . . . . . . . . . . . . . . . . . . . . .   4
    3.  KEM Combiner construction . . . . . . . . . . . . . . . . . .   4
-     3.1.  Protocol binding  . . . . . . . . . . . . . . . . . . . .   5
-   4.  Practical instantiations  . . . . . . . . . . . . . . . . . .   6
+     3.1.  Protocol binding  . . . . . . . . . . . . . . . . . . . .   6
+   4.  Practical instantiations  . . . . . . . . . . . . . . . . . .   7
      4.1.  Hash-and-counter based construction . . . . . . . . . . .   7
      4.2.  KMAC based construction . . . . . . . . . . . . . . . . .   7
-   5.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .   7
+   5.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .   8
    6.  Security Considerations . . . . . . . . . . . . . . . . . . .   8
    7.  References  . . . . . . . . . . . . . . . . . . . . . . . . .   8
      7.1.  Normative References  . . . . . . . . . . . . . . . . . .   8
      7.2.  Informative References  . . . . . . . . . . . . . . . . .   8
-   Acknowledgements  . . . . . . . . . . . . . . . . . . . . . . . .  10
+   Contributors  . . . . . . . . . . . . . . . . . . . . . . . . . .  10
+   Acknowledgements  . . . . . . . . . . . . . . . . . . . . . . . .  11
    Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  11
 
 1.  Terminology
@@ -108,8 +109,7 @@ Table of Contents
 
 
 
-
-Ounsworth & Wussler     Expires 9 September 2023                [Page 2]
+Ounsworth & Wussler     Expires 10 September 2023               [Page 2]
 
 Internet-Draft                KEM Combiner                    March 2023
 
@@ -165,7 +165,7 @@ Internet-Draft                KEM Combiner                    March 2023
 
 
 
-Ounsworth & Wussler     Expires 9 September 2023                [Page 3]
+Ounsworth & Wussler     Expires 10 September 2023               [Page 3]
 
 Internet-Draft                KEM Combiner                    March 2023
 
@@ -221,7 +221,7 @@ Internet-Draft                KEM Combiner                    March 2023
 
 
 
-Ounsworth & Wussler     Expires 9 September 2023                [Page 4]
+Ounsworth & Wussler     Expires 10 September 2023               [Page 4]
 
 Internet-Draft                KEM Combiner                    March 2023
 
@@ -235,7 +235,7 @@ Internet-Draft                KEM Combiner                    March 2023
    *  KDF represents a suitable choice of cryptographic key derivation
       function,
 
-   *  k_i represent the constant-length input keys,
+   *  k_i represent the i-th constant-length input key,
 
    *  fixedInfo is some protocol-specific KDF binding,
 
@@ -251,36 +251,51 @@ Internet-Draft                KEM Combiner                    March 2023
    The shared secret ss MAY be used as a Key Encryption Key (KEK) for
    key encapsulation.
 
-   Each k_i MUST be constant in length, therefore the secret shares ss_i
-   can be used directly only if they are guaranteed to be constant
-   length.  For all other cases, it is REQUIRED to hash them first:
+   Each k_i MUST be constant in length, therefore it is the
+   concatenation of the secret share ss_i and ciphertext ct_i only if
+   they are guaranteed to be constant length:
 
-   k_i = H(ss_i)
+   k_i = ss_i || ct_i
+
+   For all other cases, it is REQUIRED to concatenate and hash them
+   first:
+
+   k_i = H(ss_i || ct_i)
 
    Any protocols making use of this construction MUST either hash all
-   inputs ss_i, or justify that any un-hashed inputs will always be
-   fixed length.
+   inputs ss_i || ct_i, or justify that any un-hashed inputs will always
+   be fixed length.
+
+   Including the ciphertext guarantees that the combined kem is IND-CCA
+   secure as long as one of the ingredient KEMs is, as stated by
+   [KEMCombiners].
+
+
+
+
+
+
+
+
+Ounsworth & Wussler     Expires 10 September 2023               [Page 5]
+
+Internet-Draft                KEM Combiner                    March 2023
+
 
 3.1.  Protocol binding
 
    The fixedInfo string is a fixed-length string containing some
-   context-specific information.  It MUST NOT depend on the secret
-   shares.  The intention is to prevent cross-protocol attacks by making
-   this key derivation unique to its protocol context.
+   context-specific information.  The intention is to prevent cross-
+   context attacks by making this key derivation unique to its protocol
+   context.
 
    The fixedInfo string MUST have a definite structure depending on the
    protocol where all parts are fixed length.  This prevents a variable
    length structure from creating collisions between two different
    instances.  In cases some variable length input is necessary, such as
    the representation of a public key or an OID, then hashing or padding
-   can be used.
-
-
-
-Ounsworth & Wussler     Expires 9 September 2023                [Page 5]
-
-Internet-Draft                KEM Combiner                    March 2023
-
+   can be used. fixedInfo MUST NOT include the shared secrets and
+   ciphertexts, as they are already represented in the KDF input.
 
    The parameter fixedInfo MAY contain any of the following information:
 
@@ -289,8 +304,6 @@ Internet-Draft                KEM Combiner                    March 2023
 
    *  The public keys or certificates contributed by each party to the
       key-agreement transaction.
-
-   *  The ciphertext of each Key Encapsulation Mechanism.
 
    *  Other public information shared between communication parties
       before or during the transaction, such as nonces.
@@ -316,6 +329,15 @@ Internet-Draft                KEM Combiner                    March 2023
    This is a non-comprehensive list, further information can be found in
    paragraph 5.8.2 of NIST SP800-56Ar3 [SP800-56A].
 
+
+
+
+
+Ounsworth & Wussler     Expires 10 September 2023               [Page 6]
+
+Internet-Draft                KEM Combiner                    March 2023
+
+
 4.  Practical instantiations
 
    The KDF MUST be instantiated with one of the following Keccak-based
@@ -329,14 +351,6 @@ Internet-Draft                KEM Combiner                    March 2023
    3.  KDF = KMAC128 and H = SHA3-256, with hashSize = 128 bit.
 
    4.  KDF = KMAC256 and H = SHA3-512, with hashSize = 256 bit.
-
-
-
-
-Ounsworth & Wussler     Expires 9 September 2023                [Page 6]
-
-Internet-Draft                KEM Combiner                    March 2023
-
 
 4.1.  Hash-and-counter based construction
 
@@ -371,6 +385,15 @@ Internet-Draft                KEM Combiner                    March 2023
 
    *  The parameter counter MUST be the fixed value 0x00000001.
 
+
+
+
+
+Ounsworth & Wussler     Expires 10 September 2023               [Page 7]
+
+Internet-Draft                KEM Combiner                    March 2023
+
+
    To derive a shared secret ss of desired length, KMAC is called a
    single time with the input string X defined in Section 3 and length L
    being outputBits.  This is compatible with the one-step KDF
@@ -379,20 +402,6 @@ Internet-Draft                KEM Combiner                    March 2023
 5.  IANA Considerations
 
    None.
-
-
-
-
-
-
-
-
-
-
-Ounsworth & Wussler     Expires 9 September 2023                [Page 7]
-
-Internet-Draft                KEM Combiner                    March 2023
-
 
 6.  Security Considerations
 
@@ -432,6 +441,15 @@ Internet-Draft                KEM Combiner                    March 2023
               <https://datatracker.ietf.org/doc/html/draft-driscoll-pqt-
               hybrid-terminology-01>.
 
+
+
+
+
+Ounsworth & Wussler     Expires 10 September 2023               [Page 8]
+
+Internet-Draft                KEM Combiner                    March 2023
+
+
    [I-D.ietf-ipsecme-ikev2-multiple-ke]
               Tjhai, C., Tomlinson, M., Bartlett, G., Fluhrer, S., Van
               Geest, D., Garcia-Morchon, O., and V. Smyslov, "Multiple
@@ -439,16 +457,6 @@ Internet-Draft                KEM Combiner                    March 2023
               draft-ietf-ipsecme-ikev2-multiple-ke-12, 1 December 2022,
               <https://datatracker.ietf.org/doc/html/draft-ietf-ipsecme-
               ikev2-multiple-ke-12>.
-
-
-
-
-
-
-Ounsworth & Wussler     Expires 9 September 2023                [Page 8]
-
-Internet-Draft                KEM Combiner                    March 2023
-
 
    [I-D.ietf-lamps-cmp-updates]
               Brockhaus, H., von Oheimb, D., and J. Gray, "Certificate
@@ -478,6 +486,10 @@ Internet-Draft                KEM Combiner                    March 2023
               <https://datatracker.ietf.org/doc/html/draft-wussler-
               openpgp-pqc-00>.
 
+   [KEMCombiners]
+              Giacon, F., Heuer, F., and B. Poettering, "KEM Combiners",
+              2018, <https://eprint.iacr.org/2018/024>.
+
    [PQCAPI]   Project, N. P.-Q. C., "PQC - API notes", November 2022,
               <https://csrc.nist.gov/CSRC/media/Projects/Post-Quantum-
               Cryptography/documents/example-files/api-notes.pdf>.
@@ -485,6 +497,14 @@ Internet-Draft                KEM Combiner                    March 2023
    [RFC8174]  Leiba, B., "Ambiguity of Uppercase vs Lowercase in RFC
               2119 Key Words", BCP 14, RFC 8174, DOI 10.17487/RFC8174,
               May 2017, <https://www.rfc-editor.org/info/rfc8174>.
+
+
+
+
+Ounsworth & Wussler     Expires 10 September 2023               [Page 9]
+
+Internet-Draft                KEM Combiner                    March 2023
+
 
    [RFC8411]  Schaad, J. and R. Andrews, "IANA Registration for the
               Cryptographic Algorithm Object Identifier Range",
@@ -495,16 +515,6 @@ Internet-Draft                KEM Combiner                    March 2023
               Cryptographic Message Syntax (CMS)", RFC 8696,
               DOI 10.17487/RFC8696, December 2019,
               <https://www.rfc-editor.org/info/rfc8696>.
-
-
-
-
-
-
-Ounsworth & Wussler     Expires 9 September 2023                [Page 9]
-
-Internet-Draft                KEM Combiner                    March 2023
-
 
    [RFC8784]  Fluhrer, S., Kampanakis, P., McGrew, D., and V. Smyslov,
               "Mixing Preshared Keys in the Internet Key Exchange
@@ -535,6 +545,23 @@ Internet-Draft                KEM Combiner                    March 2023
               "Cryptographic sponge functions", January 2011,
               <https://keccak.team/files/CSF-0.1.pdf>.
 
+Contributors
+
+   Stavros Kousidis (BSI)
+
+
+
+
+
+
+
+
+
+Ounsworth & Wussler     Expires 10 September 2023              [Page 10]
+
+Internet-Draft                KEM Combiner                    March 2023
+
+
 Acknowledgements
 
    This document incorporates contributions and comments from a large
@@ -544,8 +571,7 @@ Acknowledgements
    electronic mail and VOIP traffic over the past years in pursuit of
    this document:
 
-   Douglas Stebila, Nimrod Aviram, Andreas Huelsing, and Stavros
-   Kousidis.
+   Douglas Stebila, Nimrod Aviram, and Andreas Huelsing.
 
    We are grateful to all, including any contributors who may have been
    inadvertently omitted from this list.
@@ -554,13 +580,6 @@ Acknowledgements
    referenced below.  Thanks go to the authors of those documents.
    "Copying always makes things easier and less error prone" -
    [RFC8411].
-
-
-
-Ounsworth & Wussler     Expires 9 September 2023               [Page 10]
-
-Internet-Draft                KEM Combiner                    March 2023
-
 
 Authors' Addresses
 
@@ -594,23 +613,4 @@ Authors' Addresses
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Ounsworth & Wussler     Expires 9 September 2023               [Page 11]
+Ounsworth & Wussler     Expires 10 September 2023              [Page 11]


### PR DESCRIPTION
As pointed out by @fluppe2 I've changed the construction to include the ciphertexts by default, inline with the paper KEM combiners from Giacon et al.

