### PR TITLE
Typos, formats and wording

### DIFF
--- a/draft-ounsworth-cfrg-kem-combiners.html
+++ b/draft-ounsworth-cfrg-kem-combiners.html
@@ -10,7 +10,7 @@
 <meta content="Stavros Kousidis" name="author">
 <meta content="
        The migration to post-quantum cryptography often calls for performing multiple key encapsulations in parallel and then combining their outputs to derive a single shared secret. 
-       This document defines a flexible multi-share KEM combiner to join an arbitrary number of key shares, that is a multi-PRF compatible with NIST SP 800-56Cr2  . The combiner defined here is CCA-secure as long as at least one of the ingredient
+       This document defines a comprehensible and easy to implement Keccak-based KEM combiner to join an arbitrary number of key shares, that is compatible with NIST SP 800-56Cr2   when viewed as a key derivation function. The combiner defined here is a multi-PRF and CCA-secure as long as at least one of the ingredient
 KEMs is. 
        
 
@@ -1184,7 +1184,7 @@ li > p:last-of-type {
 </tr></thead>
 <tfoot><tr>
 <td class="left">Ounsworth, et al.</td>
-<td class="center">Expires 13 September 2023</td>
+<td class="center">Expires 14 September 2023</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -1197,12 +1197,12 @@ li > p:last-of-type {
 <dd class="internet-draft">draft-ounsworth-cfrg-kem-combiners-02</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2023-03-12" class="published">12 March 2023</time>
+<time datetime="2023-03-13" class="published">13 March 2023</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Informational</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2023-09-13">13 September 2023</time></dd>
+<dd class="expires"><time datetime="2023-09-14">14 September 2023</time></dd>
 <dt class="label-authors">Authors:</dt>
 <dd class="authors">
 <div class="author">
@@ -1224,7 +1224,7 @@ li > p:last-of-type {
 <section id="section-abstract">
       <h2 id="abstract"><a href="#abstract" class="selfRef">Abstract</a></h2>
 <p id="section-abstract-1">The migration to post-quantum cryptography often calls for performing multiple key encapsulations in parallel and then combining their outputs to derive a single shared secret.<a href="#section-abstract-1" class="pilcrow">¶</a></p>
-<p id="section-abstract-2">This document defines a flexible multi-share KEM combiner to join an arbitrary number of key shares, that is a multi-PRF compatible with NIST SP 800-56Cr2 <span>[<a href="#SP800-56C" class="xref">SP800-56C</a>]</span>. The combiner defined here is CCA-secure as long as at least one of the ingredient
+<p id="section-abstract-2">This document defines a comprehensible and easy to implement Keccak-based KEM combiner to join an arbitrary number of key shares, that is compatible with NIST SP 800-56Cr2 <span>[<a href="#SP800-56C" class="xref">SP800-56C</a>]</span> when viewed as a key derivation function. The combiner defined here is a multi-PRF and CCA-secure as long as at least one of the ingredient
 KEMs is.<a href="#section-abstract-2" class="pilcrow">¶</a></p>
 </section>
 <section class="note rfcEditorRemove" id="section-note.1">
@@ -1261,7 +1261,7 @@ KEMs is.<a href="#section-abstract-2" class="pilcrow">¶</a></p>
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on 13 September 2023.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on 14 September 2023.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">
@@ -1349,13 +1349,10 @@ KEMs is.<a href="#section-abstract-2" class="pilcrow">¶</a></p>
             </ul>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8">
-            <p id="section-toc.1-1.8.1"><a href="#appendix-A" class="xref"></a><a href="#name-contributors-2" class="xref">Contributors</a></p>
+            <p id="section-toc.1-1.8.1"><a href="#appendix-A" class="xref"></a><a href="#name-acknowledgements-2" class="xref">Acknowledgements</a></p>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.9">
-            <p id="section-toc.1-1.9.1"><a href="#appendix-B" class="xref"></a><a href="#name-acknowledgements-2" class="xref">Acknowledgements</a></p>
-</li>
-          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.10">
-            <p id="section-toc.1-1.10.1"><a href="#appendix-C" class="xref"></a><a href="#name-authors-addresses-2" class="xref">Authors' Addresses</a></p>
+            <p id="section-toc.1-1.9.1"><a href="#appendix-B" class="xref"></a><a href="#name-authors-addresses-2" class="xref">Authors' Addresses</a></p>
 </li>
         </ul>
 </nav>
@@ -1465,7 +1462,7 @@ KDF(counter || k_1 || ... || k_n || fixedInfo, outputBits)
 <p id="section-3-6">where:<a href="#section-3-6" class="pilcrow">¶</a></p>
 <ul class="normal">
 <li class="normal" id="section-3-7.1">
-          <code>KDF</code> represents a suitable choice of cryptographic key derivation function,<a href="#section-3-7.1" class="pilcrow">¶</a>
+          <code>KDF</code> represents a suitable choice of a cryptographic key derivation function,<a href="#section-3-7.1" class="pilcrow">¶</a>
 </li>
         <li class="normal" id="section-3-7.2">
           <code>k_i</code> represent the constant-length input keys and is discussed in <a href="#sec-k_i-construction" class="xref">Section 3.1</a>,<a href="#section-3-7.2" class="pilcrow">¶</a>
@@ -1490,7 +1487,7 @@ The shared secret <code>ss</code> MAY be used directly as a symmetric key, for e
         <h3 id="name-k_i-construction-2">
 <a href="#section-3.1" class="section-number selfRef">3.1. </a><a href="#name-k_i-construction-2" class="section-name selfRef">k_i construction</a>
         </h3>
-<p id="section-3.1-1">Following the guidance of Giacon et al. <span>[<a href="#KEMC" class="xref">KEMC</a>]</span>, we wish for a KEM combiner that is CCA-secure as long as at least one of the ingredient KEMs is. Ir order to protect against chosen ciphertext attacks, it is necessary to include both the shared secret <code>ss_i</code> and its corresponding ciphertext <code>ct_i</code>. In addition, each <code>k_i</code> MUST be constant in length to prevent abuse of the underlying hash function, therefore the secret shares <code>ss_i || ct_i</code> MUST be hashed prior to inclusion in the overall construction described in <a href="#tab-kemCombiner" class="xref">Figure 1</a>:<a href="#section-3.1-1" class="pilcrow">¶</a></p>
+<p id="section-3.1-1">Following the guidance of Giacon et al. <span>[<a href="#GHP18" class="xref">GHP18</a>]</span>, we wish for a KEM combiner that is CCA-secure as long as at least one of the ingredient KEMs is. In order to protect against chosen ciphertext attacks, it is necessary to include both the shared secret <code>ss_i</code> and its corresponding ciphertext <code>ct_i</code>. In addition, each <code>k_i</code> MUST be constant in length to prevent abuse of the underlying hash function, therefore the secret shares <code>ss_i || ct_i</code> MUST be hashed prior to inclusion in the overall construction described in <a href="#tab-kemCombiner" class="xref">Figure 1</a>:<a href="#section-3.1-1" class="pilcrow">¶</a></p>
 <div class="alignLeft art-text artwork" id="section-3.1-2">
 <pre>
 k_i = H(ss_i || ct_i)
@@ -1510,7 +1507,7 @@ k_i = ss_i || ct_i
 k_i = H(ss_i || ct_i)
 </pre><a href="#section-3.1-8" class="pilcrow">¶</a>
 </div>
-<p id="section-3.1-9">Including the ciphertext guarantees that the combined kem is IND-CCA secure as long as one of the ingredient KEMs is, as stated by <span>[<a href="#KEMC" class="xref">KEMC</a>]</span>.<a href="#section-3.1-9" class="pilcrow">¶</a></p>
+<p id="section-3.1-9">Including the ciphertext guarantees that the combined kem is IND-CCA secure as long as one of the ingredient KEMs is, as stated by <span>[<a href="#GHP18" class="xref">GHP18</a>]</span>.<a href="#section-3.1-9" class="pilcrow">¶</a></p>
 <p id="section-3.1-10">Any protocols making use of this construction MUST either hash all inputs <code>ss_i || ct_i</code>, or justify that any un-hashed inputs will always be fixed length.<a href="#section-3.1-10" class="pilcrow">¶</a></p>
 <p id="section-3.1-11">~~~ END EDNOTE ~~~<a href="#section-3.1-11" class="pilcrow">¶</a></p>
 </section>
@@ -1626,7 +1623,7 @@ This is compatible with the one-step KDF definition given in NIST SP800-56Cr2 <s
       <h2 id="name-security-considerations-2">
 <a href="#section-6" class="section-number selfRef">6. </a><a href="#name-security-considerations-2" class="section-name selfRef">Security Considerations</a>
       </h2>
-<p id="section-6-1">The proposed instantiations in <a href="#sec-instantiation" class="xref">Section 4</a> are practical multi-PRFs and this specification limits to the use of Keccak-based constructions. The sponge construction was proven to be indifferentiable from a random oracle <span>[<a href="#SPONGE" class="xref">SPONGE</a>]</span>.
+<p id="section-6-1">The proposed instantiations in <a href="#sec-instantiation" class="xref">Section 4</a> are practical multi-PRFs since this specification limits to the use of Keccak-based constructions. The sponge construction was proven to be indifferentiable from a random oracle <span>[<a href="#BDPA08" class="xref">BDPA08</a>]</span>.
 More precisely, for a given capacity <code>c</code> the indifferentiability proof shows that assuming there are no weaknesses found in the Keccak permutation, an attacker has to make an expected number of <code>2^(c/2)</code> calls to the permutation to tell Keccak from a random oracle.
 For a random oracle, a difference in only a single bit gives an unrelated, uniformly random output.
 Hence, to be able to distinguish a key <code>k</code>, derived from shared keys <code>k_i</code> from a random bit string, an adversary has to correctly guess all key shares <code>k_i</code> entirely.<a href="#section-6-1" class="pilcrow">¶</a></p>
@@ -1635,11 +1632,12 @@ Hence, to be able to distinguish a key <code>k</code>, derived from shared keys 
 the newly formed combined KEM is IND-CCA2 secure as long as at least one of the
 ingredient KEMs is. Indeed, the above stated indifferentiability from a random
 oracle qualifies Keccak as a split-key pseudorandom function as defined in
-<span>[<a href="#KEMC" class="xref">KEMC</a>]</span>. That is, Keccak behaves like a random function if at least
-one input shared secret <code>ss_i</code> is picked uniformly at random. Our construction
-can thus be seen as an instantiation of the IND-CCA2 preserving Example 3 in
-Figure 1 of <span>[<a href="#KEMC" class="xref">KEMC</a>]</span>, up to some reordering of input shared secrets and
-ciphertexts and their potential compression by a cryptographic hash function.<a href="#section-6-2" class="pilcrow">¶</a></p>
+<span>[<a href="#GHP18" class="xref">GHP18</a>]</span>. That is, Keccak behaves like a random function if at least one input
+shared secret <code>ss_i</code> is picked uniformly at random. Our construction can thus
+be seen as an instantiation of the IND-CCA2 preserving Example 3 in Figure 1 of
+<span>[<a href="#GHP18" class="xref">GHP18</a>]</span>, up to some reordering of input shared secrets <code>ss_i</code> and ciphertexts
+<code>ct_i</code> and their potential compression <code>H(ss_i || ct_i)</code> by a cryptographic
+hash function.<a href="#section-6-2" class="pilcrow">¶</a></p>
 </section>
 </div>
 <section id="section-7">
@@ -1662,9 +1660,13 @@ ciphertexts and their potential compression by a cryptographic hash function.<a 
 <a href="#section-7.2" class="section-number selfRef">7.2. </a><a href="#name-informative-references-2" class="section-name selfRef">Informative References</a>
         </h3>
 <dl class="references">
-<dt id="Aviram2022">[Aviram2022]</dt>
+<dt id="ADKPRY22">[ADKPRY22]</dt>
         <dd>
 <span class="refAuthor">Aviram, N.</span>, <span class="refAuthor">Dowling, B.</span>, <span class="refAuthor">Komargodski, I.</span>, <span class="refAuthor">Paterson, K. G.</span>, <span class="refAuthor">Ronen, E.</span>, and <span class="refAuthor">E. Yogev</span>, <span class="refTitle">"Practical (Post-Quantum) Key Combiners from One-Wayness and Applications to TLS."</span>, <span>n.d.</span>, <span>&lt;<a href="https://eprint.iacr.org/2022/065">https://eprint.iacr.org/2022/065</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="BDPA08">[BDPA08]</dt>
+        <dd>
+<span class="refAuthor">Bertoni, G.</span>, <span class="refAuthor">Daemen, J.</span>, <span class="refAuthor">Peters, M.</span>, and <span class="refAuthor">G. Assche</span>, <span class="refTitle">"On the Indifferentiability of the Sponge Construction"</span>, <time datetime="2008" class="refDate">2008</time>, <span>&lt;<a href="https://doi.org/10.1007/978-3-540-78967-3_11">https://doi.org/10.1007/978-3-540-78967-3_11</a>&gt;</span>. </dd>
 <dd class="break"></dd>
 <dt id="ETSI-QHKE">[ETSI-QHKE]</dt>
         <dd>
@@ -1674,9 +1676,13 @@ ciphertexts and their potential compression by a cryptographic hash function.<a 
         <dd>
 <span class="refTitle">"SHA-3 Standard: Permutation-Based Hash and Extendable-Output Functions"</span>, <span class="seriesInfo">Federal information Processing Standards Publication (FIPS) 202 </span>, <time datetime="2015" class="refDate">2015</time>, <span>&lt;<a href="https://doi.org/10.6028/NIST.FIPS.202">https://doi.org/10.6028/NIST.FIPS.202</a>&gt;</span>. </dd>
 <dd class="break"></dd>
+<dt id="GHP18">[GHP18]</dt>
+        <dd>
+<span class="refAuthor">Giacon, F.</span>, <span class="refAuthor">Heuer, F.</span>, and <span class="refAuthor">B. Poettering</span>, <span class="refTitle">"KEM Combiners"</span>, <time datetime="2018" class="refDate">2018</time>, <span>&lt;<a href="https://doi.org/10.1007/978-3-319-76578-5_7">https://doi.org/10.1007/978-3-319-76578-5_7</a>&gt;</span>. </dd>
+<dd class="break"></dd>
 <dt id="I-D.driscoll-pqt-hybrid-terminology">[I-D.driscoll-pqt-hybrid-terminology]</dt>
         <dd>
-<span class="refAuthor">D, F.</span>, <span class="refTitle">"Terminology for Post-Quantum Traditional Hybrid Schemes"</span>, <span class="refContent">Work in Progress</span>, <span class="seriesInfo">Internet-Draft, draft-driscoll-pqt-hybrid-terminology-01</span>, <time datetime="2022-10-20" class="refDate">20 October 2022</time>, <span>&lt;<a href="https://datatracker.ietf.org/doc/html/draft-driscoll-pqt-hybrid-terminology-01">https://datatracker.ietf.org/doc/html/draft-driscoll-pqt-hybrid-terminology-01</a>&gt;</span>. </dd>
+<span class="refAuthor">Driscoll, F.</span>, <span class="refTitle">"Terminology for Post-Quantum Traditional Hybrid Schemes"</span>, <span class="refContent">Work in Progress</span>, <span class="seriesInfo">Internet-Draft, draft-driscoll-pqt-hybrid-terminology-02</span>, <time datetime="2023-03-07" class="refDate">7 March 2023</time>, <span>&lt;<a href="https://datatracker.ietf.org/api/v1/doc/document/draft-driscoll-pqt-hybrid-terminology/">https://datatracker.ietf.org/api/v1/doc/document/draft-driscoll-pqt-hybrid-terminology/</a>&gt;</span>. </dd>
 <dd class="break"></dd>
 <dt id="I-D.ietf-ipsecme-ikev2-multiple-ke">[I-D.ietf-ipsecme-ikev2-multiple-ke]</dt>
         <dd>
@@ -1697,10 +1703,6 @@ ciphertexts and their potential compression by a cryptographic hash function.<a 
 <dt id="I-D.wussler-openpgp-pqc">[I-D.wussler-openpgp-pqc]</dt>
         <dd>
 <span class="refAuthor">Kousidis, S.</span>, <span class="refAuthor">Strenzke, F.</span>, and <span class="refAuthor">A. Wussler</span>, <span class="refTitle">"Post-Quantum Cryptography in OpenPGP"</span>, <span class="refContent">Work in Progress</span>, <span class="seriesInfo">Internet-Draft, draft-wussler-openpgp-pqc-00</span>, <time datetime="2022-12-21" class="refDate">21 December 2022</time>, <span>&lt;<a href="https://datatracker.ietf.org/doc/html/draft-wussler-openpgp-pqc-00">https://datatracker.ietf.org/doc/html/draft-wussler-openpgp-pqc-00</a>&gt;</span>. </dd>
-<dd class="break"></dd>
-<dt id="KEMC">[KEMC]</dt>
-        <dd>
-<span class="refAuthor">Giacon, F.</span>, <span class="refAuthor">Heuer, F.</span>, and <span class="refAuthor">B. Poettering</span>, <span class="refTitle">"KEM Combiners"</span>, <time datetime="2018" class="refDate">2018</time>, <span>&lt;<a href="https://doi.org/10.1007/978-3-319-76578-5_7">https://doi.org/10.1007/978-3-319-76578-5_7</a>&gt;</span>. </dd>
 <dd class="break"></dd>
 <dt id="PQCAPI">[PQCAPI]</dt>
         <dd>
@@ -1731,39 +1733,27 @@ ciphertexts and their potential compression by a cryptographic hash function.<a 
 <span class="refAuthor">Barker, E.</span>, <span class="refAuthor">Chen, L.</span>, <span class="refAuthor">Roginsky, A.</span>, <span class="refAuthor">Vassilev, A.</span>, and <span class="refAuthor">R. Davis</span>, <span class="refTitle">"Recommendation for Pair-Wise Key-Establishment Schemes Using Discrete Logarithm Cryptography"</span>, <span class="seriesInfo">NIST Special Publication 800-56A </span>, <time datetime="2018-04" class="refDate">April 2018</time>, <span>&lt;<a href="https://doi.org/10.6028/NIST.SP.800-56Ar3">https://doi.org/10.6028/NIST.SP.800-56Ar3</a>&gt;</span>. </dd>
 <dd class="break"></dd>
 <dt id="SP800-56C">[SP800-56C]</dt>
-        <dd>
-<span class="refAuthor">Barker, E.</span>, <span class="refAuthor">Chen, L.</span>, and <span class="refAuthor">R. Davis</span>, <span class="refTitle">"Recommendation for Key-Derivation Methods in Key-Establishment Schemes"</span>, <span class="seriesInfo">NIST Special Publication 800-56C </span>, <time datetime="2020-08" class="refDate">August 2020</time>, <span>&lt;<a href="https://doi.org/10.6028/NIST.SP.800-56Cr2">https://doi.org/10.6028/NIST.SP.800-56Cr2</a>&gt;</span>. </dd>
-<dd class="break"></dd>
-<dt id="SPONGE">[SPONGE]</dt>
       <dd>
-<span class="refAuthor">Bertoni, G.</span>, <span class="refAuthor">Daemen, J.</span>, <span class="refAuthor">Peters, M.</span>, and <span class="refAuthor">G. Assche</span>, <span class="refTitle">"On the Indifferentiability of the Sponge Construction"</span>, <time datetime="2008" class="refDate">2008</time>, <span>&lt;<a href="https://doi.org/10.1007/978-3-540-78967-3_11">https://doi.org/10.1007/978-3-540-78967-3_11</a>&gt;</span>. </dd>
+<span class="refAuthor">Barker, E.</span>, <span class="refAuthor">Chen, L.</span>, and <span class="refAuthor">R. Davis</span>, <span class="refTitle">"Recommendation for Key-Derivation Methods in Key-Establishment Schemes"</span>, <span class="seriesInfo">NIST Special Publication 800-56C </span>, <time datetime="2020-08" class="refDate">August 2020</time>, <span>&lt;<a href="https://doi.org/10.6028/NIST.SP.800-56Cr2">https://doi.org/10.6028/NIST.SP.800-56Cr2</a>&gt;</span>. </dd>
 <dd class="break"></dd>
 </dl>
 </section>
 </section>
-<div id="contributors">
-<section id="appendix-A">
-      <h2 id="name-contributors-2">
-<a href="#name-contributors-2" class="section-name selfRef">Contributors</a>
-      </h2>
-<p id="appendix-A-1">Stavros Kousidis (BSI)<a href="#appendix-A-1" class="pilcrow">¶</a></p>
-</section>
-</div>
 <div id="acknowledgements">
-<section id="appendix-B">
+<section id="appendix-A">
       <h2 id="name-acknowledgements-2">
 <a href="#name-acknowledgements-2" class="section-name selfRef">Acknowledgements</a>
       </h2>
-<p id="appendix-B-1">This document incorporates contributions and comments from a large group of experts. The authors would especially like to acknowledge the expertise and tireless dedication of the following people, who attended many long meetings and generated millions of bytes of electronic mail and VOIP traffic over the past years in pursuit of this document:<a href="#appendix-B-1" class="pilcrow">¶</a></p>
-<p id="appendix-B-2">Douglas Stebila, Nimrod Aviram, and Andreas Huelsing.<a href="#appendix-B-2" class="pilcrow">¶</a></p>
-<p id="appendix-B-3">We are grateful to all, including any contributors who may have
-been inadvertently omitted from this list.<a href="#appendix-B-3" class="pilcrow">¶</a></p>
-<p id="appendix-B-4">This document borrows text from similar documents, including those referenced below. Thanks go to the authors of those
-   documents.  "Copying always makes things easier and less error prone" - <span>[<a href="#RFC8411" class="xref">RFC8411</a>]</span>.<a href="#appendix-B-4" class="pilcrow">¶</a></p>
+<p id="appendix-A-1">This document incorporates contributions and comments from a large group of experts. The authors would especially like to acknowledge the expertise and tireless dedication of the following people, who attended many long meetings and generated millions of bytes of electronic mail and VOIP traffic over the past years in pursuit of this document:<a href="#appendix-A-1" class="pilcrow">¶</a></p>
+<p id="appendix-A-2">Douglas Stebila, Nimrod Aviram, and Andreas Huelsing.<a href="#appendix-A-2" class="pilcrow">¶</a></p>
+<p id="appendix-A-3">We are grateful to all, including any contributors who may have
+been inadvertently omitted from this list.<a href="#appendix-A-3" class="pilcrow">¶</a></p>
+<p id="appendix-A-4">This document borrows text from similar documents, including those referenced below. Thanks go to the authors of those
+   documents.  "Copying always makes things easier and less error prone" - <span>[<a href="#RFC8411" class="xref">RFC8411</a>]</span>.<a href="#appendix-A-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="authors-addresses">
-<section id="appendix-C">
+<section id="appendix-B">
       <h2 id="name-authors-addresses-2">
 <a href="#name-authors-addresses-2" class="section-name selfRef">Authors' Addresses</a>
       </h2>

--- a/draft-ounsworth-cfrg-kem-combiners.mkd
+++ b/draft-ounsworth-cfrg-kem-combiners.mkd
@@ -41,7 +41,6 @@ author:
       abbrev: Proton
       country: Switzerland
       email: aron@wussler.it
-
     -
       ins: S. Kousidis
       name: Stavros Kousidis
@@ -133,7 +132,7 @@ informative:
     date: 2015
     seriesinfo:
       Federal information Processing Standards Publication (FIPS) 202
-  SPONGE:
+  BDPA08:
     target: "https://doi.org/10.1007/978-3-540-78967-3_11"
     title: On the Indifferentiability of the Sponge Construction
     author:
@@ -150,7 +149,7 @@ informative:
         ins: G. Assche
         name: Gilles van Assche
     date: 2008
-  KEMC:
+  GHP18:
     target: https://doi.org/10.1007/978-3-319-76578-5_7
     title: KEM Combiners
     date: 2018
@@ -170,7 +169,7 @@ informative:
     date: 2020-12
     seriesinfo:
       ETSI TS 103 744 V1.1.1
-  Aviram2022:
+  ADKPRY22:
     title: "Practical (Post-Quantum) Key Combiners from One-Wayness and Applications to TLS."
     target: "https://eprint.iacr.org/2022/065"
     author:
@@ -192,13 +191,12 @@ informative:
       -
         ins: E. Yogev
         name: Eylon Yogev
-        ins: 
 
 --- abstract
 
 The migration to post-quantum cryptography often calls for performing multiple key encapsulations in parallel and then combining their outputs to derive a single shared secret.
 
-This document defines a flexible multi-share KEM combiner to join an arbitrary number of key shares, that is a multi-PRF compatible with NIST SP 800-56Cr2 [SP800-56C]. The combiner defined here is CCA-secure as long as at least one of the ingredient
+This document defines a comprehensible and easy to implement Keccak-based KEM combiner to join an arbitrary number of key shares, that is compatible with NIST SP 800-56Cr2 [SP800-56C] when viewed as a key derivation function. The combiner defined here is a multi-PRF and CCA-secure as long as at least one of the ingredient
 KEMs is.
 
 <!-- End of Abstract -->
@@ -284,7 +282,7 @@ KDF(counter || k_1 || ... || k_n || fixedInfo, outputBits)
 
 where:
 
-- `KDF` represents a suitable choice of cryptographic key derivation function,
+- `KDF` represents a suitable choice of a cryptographic key derivation function,
 - `k_i` represent the constant-length input keys and is discussed in {{sec-k_i-construction}},
 - `fixedInfo` is some protocol-specific KDF binding,
 - `counter` parameter is instantiation-specific and is discussed in {{sec-instantiation}}.
@@ -296,7 +294,7 @@ The shared secret `ss` MAY be used directly as a symmetric key, for example as a
 
 ## k_i construction {#sec-k_i-construction}
 
-Following the guidance of Giacon et al. [KEMC], we wish for a KEM combiner that is CCA-secure as long as at least one of the ingredient KEMs is. Ir order to protect against chosen ciphertext attacks, it is necessary to include both the shared secret `ss_i` and its corresponding ciphertext `ct_i`. In addition, each `k_i` MUST be constant in length to prevent abuse of the underlying hash function, therefore the secret shares `ss_i || ct_i` MUST be hashed prior to inclusion in the overall construction described in {{tab-kemCombiner}}:
+Following the guidance of Giacon et al. [GHP18], we wish for a KEM combiner that is CCA-secure as long as at least one of the ingredient KEMs is. In order to protect against chosen ciphertext attacks, it is necessary to include both the shared secret `ss_i` and its corresponding ciphertext `ct_i`. In addition, each `k_i` MUST be constant in length to prevent abuse of the underlying hash function, therefore the secret shares `ss_i || ct_i` MUST be hashed prior to inclusion in the overall construction described in {{tab-kemCombiner}}:
 
 ~~~
 k_i = H(ss_i || ct_i)
@@ -319,7 +317,7 @@ For all other cases, it is REQUIRED to concatenate and hash them first:
 k_i = H(ss_i || ct_i)
 ~~~
 
-Including the ciphertext guarantees that the combined kem is IND-CCA secure as long as one of the ingredient KEMs is, as stated by [KEMC].
+Including the ciphertext guarantees that the combined kem is IND-CCA secure as long as one of the ingredient KEMs is, as stated by [GHP18].
 
 Any protocols making use of this construction MUST either hash all inputs `ss_i || ct_i`, or justify that any un-hashed inputs will always be fixed length.
 
@@ -387,7 +385,7 @@ None.
 
 # Security Considerations
 
-The proposed instantiations in {{sec-instantiation}} are practical multi-PRFs and this specification limits to the use of Keccak-based constructions. The sponge construction was proven to be indifferentiable from a random oracle {{SPONGE}}.
+The proposed instantiations in {{sec-instantiation}} are practical multi-PRFs since this specification limits to the use of Keccak-based constructions. The sponge construction was proven to be indifferentiable from a random oracle {{BDPA08}}.
 More precisely, for a given capacity `c` the indifferentiability proof shows that assuming there are no weaknesses found in the Keccak permutation, an attacker has to make an expected number of `2^(c/2)` calls to the permutation to tell Keccak from a random oracle.
 For a random oracle, a difference in only a single bit gives an unrelated, uniformly random output.
 Hence, to be able to distinguish a key `k`, derived from shared keys `k_i` from a random bit string, an adversary has to correctly guess all key shares `k_i` entirely.
@@ -397,19 +395,15 @@ The proposed construction in {{sec-kem-combiner}} with the instantiations in
 the newly formed combined KEM is IND-CCA2 secure as long as at least one of the
 ingredient KEMs is. Indeed, the above stated indifferentiability from a random
 oracle qualifies Keccak as a split-key pseudorandom function as defined in
-{{KEMC}}. That is, Keccak behaves like a random function if at least
-one input shared secret `ss_i` is picked uniformly at random. Our construction
-can thus be seen as an instantiation of the IND-CCA2 preserving Example 3 in
-Figure 1 of {{KEMC}}, up to some reordering of input shared secrets and
-ciphertexts and their potential compression by a cryptographic hash function. 
+{{GHP18}}. That is, Keccak behaves like a random function if at least one input
+shared secret `ss_i` is picked uniformly at random. Our construction can thus
+be seen as an instantiation of the IND-CCA2 preserving Example 3 in Figure 1 of
+{{GHP18}}, up to some reordering of input shared secrets `ss_i` and ciphertexts
+`ct_i` and their potential compression `H(ss_i || ct_i)` by a cryptographic
+hash function. 
 
 <!-- Start of Appendices -->
 --- back
-
-# Contributors
-{:numbered="false"}
-
-Stavros Kousidis (BSI)
 
 # Acknowledgements
 {:numbered="false"}

--- a/draft-ounsworth-cfrg-kem-combiners.txt
+++ b/draft-ounsworth-cfrg-kem-combiners.txt
@@ -5,10 +5,10 @@
 CFRG                                                        M. Ounsworth
 Internet-Draft                                                   Entrust
 Intended status: Informational                                A. Wussler
-Expires: 13 September 2023                                        Proton
+Expires: 14 September 2023                                        Proton
                                                              S. Kousidis
                                                                      BSI
-                                                           12 March 2023
+                                                           13 March 2023
 
 
 Combiner function for hybrid key encapsulation mechanisms (Hybrid KEMs)
@@ -20,10 +20,11 @@ Abstract
    multiple key encapsulations in parallel and then combining their
    outputs to derive a single shared secret.
 
-   This document defines a flexible multi-share KEM combiner to join an
-   arbitrary number of key shares, that is a multi-PRF compatible with
-   NIST SP 800-56Cr2 [SP800-56C].  The combiner defined here is CCA-
-   secure as long as at least one of the ingredient KEMs is.
+   This document defines a comprehensible and easy to implement Keccak-
+   based KEM combiner to join an arbitrary number of key shares, that is
+   compatible with NIST SP 800-56Cr2 [SP800-56C] when viewed as a key
+   derivation function.  The combiner defined here is a multi-PRF and
+   CCA-secure as long as at least one of the ingredient KEMs is.
 
 About This Document
 
@@ -52,8 +53,7 @@ Status of This Memo
 
 
 
-
-Ounsworth, et al.       Expires 13 September 2023               [Page 1]
+Ounsworth, et al.       Expires 14 September 2023               [Page 1]
 
 Internet-Draft                KEM Combiner                    March 2023
 
@@ -68,7 +68,7 @@ Internet-Draft                KEM Combiner                    March 2023
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 13 September 2023.
+   This Internet-Draft will expire on 14 September 2023.
 
 Copyright Notice
 
@@ -100,7 +100,6 @@ Table of Contents
    7.  References  . . . . . . . . . . . . . . . . . . . . . . . . .   9
      7.1.  Normative References  . . . . . . . . . . . . . . . . . .   9
      7.2.  Informative References  . . . . . . . . . . . . . . . . .   9
-   Contributors  . . . . . . . . . . . . . . . . . . . . . . . . . .  12
    Acknowledgements  . . . . . . . . . . . . . . . . . . . . . . . .  12
    Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  12
 
@@ -109,7 +108,8 @@ Table of Contents
 
 
 
-Ounsworth, et al.       Expires 13 September 2023               [Page 2]
+
+Ounsworth, et al.       Expires 14 September 2023               [Page 2]
 
 Internet-Draft                KEM Combiner                    March 2023
 
@@ -165,7 +165,7 @@ Internet-Draft                KEM Combiner                    March 2023
 
 
 
-Ounsworth, et al.       Expires 13 September 2023               [Page 3]
+Ounsworth, et al.       Expires 14 September 2023               [Page 3]
 
 Internet-Draft                KEM Combiner                    March 2023
 
@@ -221,7 +221,7 @@ Internet-Draft                KEM Combiner                    March 2023
 
 
 
-Ounsworth, et al.       Expires 13 September 2023               [Page 4]
+Ounsworth, et al.       Expires 14 September 2023               [Page 4]
 
 Internet-Draft                KEM Combiner                    March 2023
 
@@ -246,7 +246,7 @@ Internet-Draft                KEM Combiner                    March 2023
 
    where:
 
-   *  KDF represents a suitable choice of cryptographic key derivation
+   *  KDF represents a suitable choice of a cryptographic key derivation
       function,
 
    *  k_i represent the constant-length input keys and is discussed in
@@ -268,16 +268,16 @@ Internet-Draft                KEM Combiner                    March 2023
 
 3.1.  k_i construction
 
-   Following the guidance of Giacon et al.  [KEMC], we wish for a KEM
+   Following the guidance of Giacon et al.  [GHP18], we wish for a KEM
    combiner that is CCA-secure as long as at least one of the ingredient
-   KEMs is.  Ir order to protect against chosen ciphertext attacks, it
+   KEMs is.  In order to protect against chosen ciphertext attacks, it
    is necessary to include both the shared secret ss_i and its
    corresponding ciphertext ct_i.  In addition, each k_i MUST be
    constant in length to prevent abuse of the underlying hash function,
 
 
 
-Ounsworth, et al.       Expires 13 September 2023               [Page 5]
+Ounsworth, et al.       Expires 14 September 2023               [Page 5]
 
 Internet-Draft                KEM Combiner                    March 2023
 
@@ -303,7 +303,8 @@ Internet-Draft                KEM Combiner                    March 2023
    k_i = H(ss_i || ct_i)
 
    Including the ciphertext guarantees that the combined kem is IND-CCA
-   secure as long as one of the ingredient KEMs is, as stated by [KEMC].
+   secure as long as one of the ingredient KEMs is, as stated by
+   [GHP18].
 
    Any protocols making use of this construction MUST either hash all
    inputs ss_i || ct_i, or justify that any un-hashed inputs will always
@@ -332,8 +333,7 @@ Internet-Draft                KEM Combiner                    March 2023
 
 
 
-
-Ounsworth, et al.       Expires 13 September 2023               [Page 6]
+Ounsworth, et al.       Expires 14 September 2023               [Page 6]
 
 Internet-Draft                KEM Combiner                    March 2023
 
@@ -389,7 +389,7 @@ Internet-Draft                KEM Combiner                    March 2023
 
 
 
-Ounsworth, et al.       Expires 13 September 2023               [Page 7]
+Ounsworth, et al.       Expires 14 September 2023               [Page 7]
 
 Internet-Draft                KEM Combiner                    March 2023
 
@@ -445,38 +445,38 @@ Internet-Draft                KEM Combiner                    March 2023
 
 
 
-Ounsworth, et al.       Expires 13 September 2023               [Page 8]
+Ounsworth, et al.       Expires 14 September 2023               [Page 8]
 
 Internet-Draft                KEM Combiner                    March 2023
 
 
 6.  Security Considerations
 
-   The proposed instantiations in Section 4 are practical multi-PRFs and
-   this specification limits to the use of Keccak-based constructions.
-   The sponge construction was proven to be indifferentiable from a
-   random oracle [SPONGE].  More precisely, for a given capacity c the
-   indifferentiability proof shows that assuming there are no weaknesses
-   found in the Keccak permutation, an attacker has to make an expected
-   number of 2^(c/2) calls to the permutation to tell Keccak from a
-   random oracle.  For a random oracle, a difference in only a single
-   bit gives an unrelated, uniformly random output.  Hence, to be able
-   to distinguish a key k, derived from shared keys k_i from a random
-   bit string, an adversary has to correctly guess all key shares k_i
-   entirely.
+   The proposed instantiations in Section 4 are practical multi-PRFs
+   since this specification limits to the use of Keccak-based
+   constructions.  The sponge construction was proven to be
+   indifferentiable from a random oracle [BDPA08].  More precisely, for
+   a given capacity c the indifferentiability proof shows that assuming
+   there are no weaknesses found in the Keccak permutation, an attacker
+   has to make an expected number of 2^(c/2) calls to the permutation to
+   tell Keccak from a random oracle.  For a random oracle, a difference
+   in only a single bit gives an unrelated, uniformly random output.
+   Hence, to be able to distinguish a key k, derived from shared keys
+   k_i from a random bit string, an adversary has to correctly guess all
+   key shares k_i entirely.
 
    The proposed construction in Section 3 with the instantiations in
    Section 4 preserves IND-CCA2 of any of its ingredient KEMs, i.e. the
    newly formed combined KEM is IND-CCA2 secure as long as at least one
    of the ingredient KEMs is.  Indeed, the above stated
    indifferentiability from a random oracle qualifies Keccak as a split-
-   key pseudorandom function as defined in [KEMC].  That is, Keccak
+   key pseudorandom function as defined in [GHP18].  That is, Keccak
    behaves like a random function if at least one input shared secret
    ss_i is picked uniformly at random.  Our construction can thus be
    seen as an instantiation of the IND-CCA2 preserving Example 3 in
-   Figure 1 of [KEMC], up to some reordering of input shared secrets and
-   ciphertexts and their potential compression by a cryptographic hash
-   function.
+   Figure 1 of [GHP18], up to some reordering of input shared secrets
+   ss_i and ciphertexts ct_i and their potential compression H(ss_i ||
+   ct_i) by a cryptographic hash function.
 
 7.  References
 
@@ -489,19 +489,19 @@ Internet-Draft                KEM Combiner                    March 2023
 
 7.2.  Informative References
 
-   [Aviram2022]
-              Aviram, N., Dowling, B., Komargodski, I., Paterson, K. G.,
+   [ADKPRY22] Aviram, N., Dowling, B., Komargodski, I., Paterson, K. G.,
               Ronen, E., and E. Yogev, "Practical (Post-Quantum) Key
               Combiners from One-Wayness and Applications to TLS.",
               n.d., <https://eprint.iacr.org/2022/065>.
 
+   [BDPA08]   Bertoni, G., Daemen, J., Peters, M., and G. Assche, "On
+              the Indifferentiability of the Sponge Construction", 2008,
+              <https://doi.org/10.1007/978-3-540-78967-3_11>.
 
 
 
 
-
-
-Ounsworth, et al.       Expires 13 September 2023               [Page 9]
+Ounsworth, et al.       Expires 14 September 2023               [Page 9]
 
 Internet-Draft                KEM Combiner                    March 2023
 
@@ -517,12 +517,15 @@ Internet-Draft                KEM Combiner                    March 2023
               Standards Publication (FIPS) 202 , 2015,
               <https://doi.org/10.6028/NIST.FIPS.202>.
 
+   [GHP18]    Giacon, F., Heuer, F., and B. Poettering, "KEM Combiners",
+              2018, <https://doi.org/10.1007/978-3-319-76578-5_7>.
+
    [I-D.driscoll-pqt-hybrid-terminology]
-              D, F., "Terminology for Post-Quantum Traditional Hybrid
-              Schemes", Work in Progress, Internet-Draft, draft-
-              driscoll-pqt-hybrid-terminology-01, 20 October 2022,
-              <https://datatracker.ietf.org/doc/html/draft-driscoll-pqt-
-              hybrid-terminology-01>.
+              Driscoll, F., "Terminology for Post-Quantum Traditional
+              Hybrid Schemes", Work in Progress, Internet-Draft, draft-
+              driscoll-pqt-hybrid-terminology-02, 7 March 2023,
+              <https://datatracker.ietf.org/api/v1/doc/document/draft-
+              driscoll-pqt-hybrid-terminology/>.
 
    [I-D.ietf-ipsecme-ikev2-multiple-ke]
               Tjhai, C., Tomlinson, M., Bartlett, G., Fluhrer, S., Van
@@ -546,6 +549,19 @@ Internet-Draft                KEM Combiner                    March 2023
               <https://datatracker.ietf.org/doc/html/draft-ietf-tls-
               hybrid-design-06>.
 
+
+
+
+
+
+
+
+
+Ounsworth, et al.       Expires 14 September 2023              [Page 10]
+
+Internet-Draft                KEM Combiner                    March 2023
+
+
    [I-D.ounsworth-pq-composite-kem]
               Ounsworth, M. and J. Gray, "Composite KEM For Use In
               Internet PKI", Work in Progress, Internet-Draft, draft-
@@ -553,24 +569,12 @@ Internet-Draft                KEM Combiner                    March 2023
               <https://datatracker.ietf.org/doc/html/draft-ounsworth-pq-
               composite-kem-00>.
 
-
-
-
-
-Ounsworth, et al.       Expires 13 September 2023              [Page 10]
-
-Internet-Draft                KEM Combiner                    March 2023
-
-
    [I-D.wussler-openpgp-pqc]
               Kousidis, S., Strenzke, F., and A. Wussler, "Post-Quantum
               Cryptography in OpenPGP", Work in Progress, Internet-
               Draft, draft-wussler-openpgp-pqc-00, 21 December 2022,
               <https://datatracker.ietf.org/doc/html/draft-wussler-
               openpgp-pqc-00>.
-
-   [KEMC]     Giacon, F., Heuer, F., and B. Poettering, "KEM Combiners",
-              2018, <https://doi.org/10.1007/978-3-319-76578-5_7>.
 
    [PQCAPI]   Project, N. P.-Q. C., "PQC - API notes", November 2022,
               <https://csrc.nist.gov/CSRC/media/Projects/Post-Quantum-
@@ -602,6 +606,18 @@ Internet-Draft                KEM Combiner                    March 2023
               NIST Special Publication 800-185 , 2016,
               <https://doi.org/10.6028/NIST.SP.800-185>.
 
+
+
+
+
+
+
+
+Ounsworth, et al.       Expires 14 September 2023              [Page 11]
+
+Internet-Draft                KEM Combiner                    March 2023
+
+
    [SP800-56A]
               Barker, E., Chen, L., Roginsky, A., Vassilev, A., and R.
               Davis, "Recommendation for Pair-Wise Key-Establishment
@@ -609,28 +625,11 @@ Internet-Draft                KEM Combiner                    March 2023
               Special Publication 800-56A , April 2018,
               <https://doi.org/10.6028/NIST.SP.800-56Ar3>.
 
-
-
-
-
-Ounsworth, et al.       Expires 13 September 2023              [Page 11]
-
-Internet-Draft                KEM Combiner                    March 2023
-
-
    [SP800-56C]
               Barker, E., Chen, L., and R. Davis, "Recommendation for
               Key-Derivation Methods in Key-Establishment Schemes", NIST
               Special Publication 800-56C , August 2020,
               <https://doi.org/10.6028/NIST.SP.800-56Cr2>.
-
-   [SPONGE]   Bertoni, G., Daemen, J., Peters, M., and G. Assche, "On
-              the Indifferentiability of the Sponge Construction", 2008,
-              <https://doi.org/10.1007/978-3-540-78967-3_11>.
-
-Contributors
-
-   Stavros Kousidis (BSI)
 
 Acknowledgements
 
@@ -669,7 +668,8 @@ Authors' Addresses
 
 
 
-Ounsworth, et al.       Expires 13 September 2023              [Page 12]
+
+Ounsworth, et al.       Expires 14 September 2023              [Page 12]
 
 Internet-Draft                KEM Combiner                    March 2023
 
@@ -725,4 +725,4 @@ Internet-Draft                KEM Combiner                    March 2023
 
 
 
-Ounsworth, et al.       Expires 13 September 2023              [Page 13]
+Ounsworth, et al.       Expires 14 September 2023              [Page 13]


### PR DESCRIPTION
This PR:

- Some typos
- Proposes to align reference abbreviations for scientific literature to the common form: Initials+Year
- Proposes some wording for the abstract, grouping the keywords "comprehensible", "implementation ease", "compatibility" into the first sentence and the keywords "multi-PRF", "CCA-secure" into the second.
- Makes the CCA security considerations a bit more explicit in the last sentence, to hopefully be a bit more comprehensible.