### PR TITLE
Rename multi-PRF into split-key PRF

### DIFF
--- a/draft-ounsworth-cfrg-kem-combiners.html
+++ b/draft-ounsworth-cfrg-kem-combiners.html
@@ -10,7 +10,7 @@
 <meta content="Stavros Kousidis" name="author">
 <meta content="
        The migration to post-quantum cryptography often calls for performing multiple key encapsulations in parallel and then combining their outputs to derive a single shared secret. 
-       This document defines a comprehensible and easy to implement Keccak-based KEM combiner to join an arbitrary number of key shares, that is compatible with NIST SP 800-56Cr2   when viewed as a key derivation function. The combiners defined here are practical multi-PRFs and are CCA-secure as long as at least one of the ingredient KEMs is. 
+       This document defines a comprehensible and easy to implement Keccak-based KEM combiner to join an arbitrary number of key shares, that is compatible with NIST SP 800-56Cr2   when viewed as a key derivation function. The combiners defined here are practical split-key PRFs and are CCA-secure as long as at least one of the ingredient KEMs is. 
        
 
 
@@ -22,7 +22,6 @@
 <!-- Generator version information:
   xml2rfc 3.12.2
     Python 3.10.6
-    weasyprint 54.1
 -->
 <link href="draft-ounsworth-cfrg-kem-combiners.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
@@ -1223,7 +1222,7 @@ li > p:last-of-type {
 <section id="section-abstract">
       <h2 id="abstract"><a href="#abstract" class="selfRef">Abstract</a></h2>
 <p id="section-abstract-1">The migration to post-quantum cryptography often calls for performing multiple key encapsulations in parallel and then combining their outputs to derive a single shared secret.<a href="#section-abstract-1" class="pilcrow">¶</a></p>
-<p id="section-abstract-2">This document defines a comprehensible and easy to implement Keccak-based KEM combiner to join an arbitrary number of key shares, that is compatible with NIST SP 800-56Cr2 <span>[<a href="#SP800-56C" class="xref">SP800-56C</a>]</span> when viewed as a key derivation function. The combiners defined here are practical multi-PRFs and are CCA-secure as long as at least one of the ingredient KEMs is.<a href="#section-abstract-2" class="pilcrow">¶</a></p>
+<p id="section-abstract-2">This document defines a comprehensible and easy to implement Keccak-based KEM combiner to join an arbitrary number of key shares, that is compatible with NIST SP 800-56Cr2 <span>[<a href="#SP800-56C" class="xref">SP800-56C</a>]</span> when viewed as a key derivation function. The combiners defined here are practical split-key PRFs and are CCA-secure as long as at least one of the ingredient KEMs is.<a href="#section-abstract-2" class="pilcrow">¶</a></p>
 </section>
 <section class="note rfcEditorRemove" id="section-note.1">
       <h2 id="name-about-this-document-2">
@@ -1450,7 +1449,7 @@ ss = kemCombiner(ss_1, ss_2, ..., ss_n)
 </pre><a href="#section-3-2" class="pilcrow">¶</a>
 </div>
 <p id="section-3-3">This document assumes that shared secrets are the output of a KEM, but without loss of generality they MAY also be any other source of cryptographic key material, such as pre-shared keys (PSKs), with PQ/PSK being a quantum-safe migration strategy being made available by some protocols, see for example IKEv2 in <span>[<a href="#RFC8784" class="xref">RFC8784</a>]</span>.<a href="#section-3-3" class="pilcrow">¶</a></p>
-<p id="section-3-4">In general it is desirable to use a multi-PRF as a KEM combiner, meaning that the combiner has the properties of a PRF when keyed by any of its single inputs.
+<p id="section-3-4">In general it is desirable to use a split-key PRF as a KEM combiner, meaning that the combiner has the properties of a PRF when keyed by any of its single inputs.
 The following simple yet generic construction can be used in all IETF protocols that need to combine the output of two or more KEMs:<a href="#section-3-4" class="pilcrow">¶</a></p>
 <span id="name-general-kem-combiner-constru"></span><div id="tab-kemCombiner">
 <figure id="figure-1">
@@ -1611,7 +1610,7 @@ s = v || rlen(v) ; v may have variable length
       <h2 id="name-practical-instantiations-2">
 <a href="#section-4" class="section-number selfRef">4. </a><a href="#name-practical-instantiations-2" class="section-name selfRef">Practical instantiations</a>
       </h2>
-<p id="section-4-1">The KDF must be instantiated with cryptographically-secure choices for <code>KDF</code>. The following are RECOMMENDED Keccak-based instatiations, but other choices MAY be made for example to allow for future cryptographic agility. A protocol using a different instantiation MUST justify that it will behave as a multi-PRF.<a href="#section-4-1" class="pilcrow">¶</a></p>
+<p id="section-4-1">The KDF must be instantiated with cryptographically-secure choices for <code>KDF</code>. The following are RECOMMENDED Keccak-based instatiations, but other choices MAY be made for example to allow for future cryptographic agility. A protocol using a different instantiation MUST justify that it will behave as a split-key PRF, as required in <span>[<a href="#GHP18" class="xref">GHP18</a>]</span>.<a href="#section-4-1" class="pilcrow">¶</a></p>
 <p id="section-4-2">Each instance defines a function to be used as <code>KDF</code>, a <code>hashSize</code> to determine parameter size, and optionally a <code>counter</code>:<a href="#section-4-2" class="pilcrow">¶</a></p>
 <ol start="1" type="1" class="normal type-1" id="section-4-3">
 <li id="section-4-3.1">
@@ -1627,7 +1626,7 @@ s = v || rlen(v) ; v may have variable length
           <code>KDF = SHA3-512</code>, with <code>hashSize = 512 bit</code>.<a href="#section-4-3.4" class="pilcrow">¶</a>
 </li>
       </ol>
-<p id="section-4-4">As justified in the security considerations, we recommend only Keccak-based instantiations because assuming there are no weaknesses found in the Keccak permutation, it behaves as a multi-PRF that can be keyed by any input <code>k_i</code>.
+<p id="section-4-4">As justified in the security considerations, we recommend only Keccak-based instantiations because assuming there are no weaknesses found in the Keccak permutation, it behaves as a split-key PRF that can be keyed by any input <code>k_i</code>.
 SHAKE is also not included in the list as it is not allowed by <span>[<a href="#SP800-56A" class="xref">SP800-56A</a>]</span> section 7, and does not provide any implementation advantage over KMAC.<a href="#section-4-4" class="pilcrow">¶</a></p>
 <p id="section-4-5">KMAC constructions are RECOMMENDED over SHA-3, as KMAC offers a simple cSHAKE-based construction, with the advantage of returning an unrelated output when requesting a different <code>outputBits</code> KEK length.<a href="#section-4-5" class="pilcrow">¶</a></p>
 <div id="kmac-based-construction">
@@ -1684,7 +1683,7 @@ To generate an <code>outputBits</code> long secret share <code>ss</code>:<a href
       <h2 id="name-security-considerations-2">
 <a href="#section-6" class="section-number selfRef">6. </a><a href="#name-security-considerations-2" class="section-name selfRef">Security Considerations</a>
       </h2>
-<p id="section-6-1">The proposed instantiations in <a href="#sec-instantiation" class="xref">Section 4</a> are practical multi-PRFs since this specification limits to the use of Keccak-based constructions. The sponge construction was proven to be indifferentiable from a random oracle <span>[<a href="#BDPA08" class="xref">BDPA08</a>]</span>.
+<p id="section-6-1">The proposed instantiations in <a href="#sec-instantiation" class="xref">Section 4</a> are practical split-key PRFs since this specification limits to the use of Keccak-based constructions. The sponge construction was proven to be indifferentiable from a random oracle <span>[<a href="#BDPA08" class="xref">BDPA08</a>]</span>.
 More precisely, for a given capacity <code>c</code> the indifferentiability proof shows that assuming there are no weaknesses found in the Keccak permutation, an attacker has to make an expected number of <code>2^(c/2)</code> calls to the permutation to tell Keccak from a random oracle.
 For a random oracle, a difference in only a single bit gives an unrelated, uniformly random output.
 Hence, to be able to distinguish a key <code>k</code>, derived from shared keys <code>k_i</code> from a random bit string, an adversary has to correctly guess all key shares <code>k_i</code> entirely.<a href="#section-6-1" class="pilcrow">¶</a></p>

--- a/draft-ounsworth-cfrg-kem-combiners.mkd
+++ b/draft-ounsworth-cfrg-kem-combiners.mkd
@@ -196,7 +196,7 @@ informative:
 
 The migration to post-quantum cryptography often calls for performing multiple key encapsulations in parallel and then combining their outputs to derive a single shared secret.
 
-This document defines a comprehensible and easy to implement Keccak-based KEM combiner to join an arbitrary number of key shares, that is compatible with NIST SP 800-56Cr2 [SP800-56C] when viewed as a key derivation function. The combiners defined here are practical multi-PRFs and are CCA-secure as long as at least one of the ingredient KEMs is.
+This document defines a comprehensible and easy to implement Keccak-based KEM combiner to join an arbitrary number of key shares, that is compatible with NIST SP 800-56Cr2 [SP800-56C] when viewed as a key derivation function. The combiners defined here are practical split-key PRFs and are CCA-secure as long as at least one of the ingredient KEMs is.
 
 
 <!-- End of Abstract -->
@@ -272,7 +272,7 @@ ss = kemCombiner(ss_1, ss_2, ..., ss_n)
 
 This document assumes that shared secrets are the output of a KEM, but without loss of generality they MAY also be any other source of cryptographic key material, such as pre-shared keys (PSKs), with PQ/PSK being a quantum-safe migration strategy being made available by some protocols, see for example IKEv2 in [RFC8784].
 
-In general it is desirable to use a multi-PRF as a KEM combiner, meaning that the combiner has the properties of a PRF when keyed by any of its single inputs.
+In general it is desirable to use a split-key PRF as a KEM combiner, meaning that the combiner has the properties of a PRF when keyed by any of its single inputs.
 The following simple yet generic construction can be used in all IETF protocols that need to combine the output of two or more KEMs:
 
 ~~~
@@ -396,7 +396,7 @@ This is a non-comprehensive list, further information can be found in paragraph 
 
 # Practical instantiations {#sec-instantiation}
 
-The KDF must be instantiated with cryptographically-secure choices for `KDF`. The following are RECOMMENDED Keccak-based instatiations, but other choices MAY be made for example to allow for future cryptographic agility. A protocol using a different instantiation MUST justify that it will behave as a multi-PRF.
+The KDF must be instantiated with cryptographically-secure choices for `KDF`. The following are RECOMMENDED Keccak-based instatiations, but other choices MAY be made for example to allow for future cryptographic agility. A protocol using a different instantiation MUST justify that it will behave as a split-key PRF, as required in {{GHP18}}.
 
 Each instance defines a function to be used as `KDF`, a `hashSize` to determine parameter size, and optionally a `counter`:
 
@@ -405,7 +405,7 @@ Each instance defines a function to be used as `KDF`, a `hashSize` to determine 
 1. `KDF = SHA3-256`, with `hashSize = 256 bit`.
 1. `KDF = SHA3-512`, with `hashSize = 512 bit`.
 
-As justified in the security considerations, we recommend only Keccak-based instantiations because assuming there are no weaknesses found in the Keccak permutation, it behaves as a multi-PRF that can be keyed by any input `k_i`.
+As justified in the security considerations, we recommend only Keccak-based instantiations because assuming there are no weaknesses found in the Keccak permutation, it behaves as a split-key PRF that can be keyed by any input `k_i`.
 SHAKE is also not included in the list as it is not allowed by {{SP800-56A}} section 7, and does not provide any implementation advantage over KMAC.
 
 KMAC constructions are RECOMMENDED over SHA-3, as KMAC offers a simple cSHAKE-based construction, with the advantage of returning an unrelated output when requesting a different `outputBits` KEK length.
@@ -438,7 +438,7 @@ None.
 
 # Security Considerations
 
-The proposed instantiations in {{sec-instantiation}} are practical multi-PRFs since this specification limits to the use of Keccak-based constructions. The sponge construction was proven to be indifferentiable from a random oracle {{BDPA08}}.
+The proposed instantiations in {{sec-instantiation}} are practical split-key PRFs since this specification limits to the use of Keccak-based constructions. The sponge construction was proven to be indifferentiable from a random oracle {{BDPA08}}.
 More precisely, for a given capacity `c` the indifferentiability proof shows that assuming there are no weaknesses found in the Keccak permutation, an attacker has to make an expected number of `2^(c/2)` calls to the permutation to tell Keccak from a random oracle.
 For a random oracle, a difference in only a single bit gives an unrelated, uniformly random output.
 Hence, to be able to distinguish a key `k`, derived from shared keys `k_i` from a random bit string, an adversary has to correctly guess all key shares `k_i` entirely.

--- a/draft-ounsworth-cfrg-kem-combiners.txt
+++ b/draft-ounsworth-cfrg-kem-combiners.txt
@@ -23,8 +23,8 @@ Abstract
    This document defines a comprehensible and easy to implement Keccak-
    based KEM combiner to join an arbitrary number of key shares, that is
    compatible with NIST SP 800-56Cr2 [SP800-56C] when viewed as a key
-   derivation function.  The combiners defined here are practical multi-
-   PRFs and are CCA-secure as long as at least one of the ingredient
+   derivation function.  The combiners defined here are practical split-
+   key PRFs and are CCA-secure as long as at least one of the ingredient
    KEMs is.
 
 About This Document
@@ -234,7 +234,7 @@ Internet-Draft                KEM Combiner                     July 2023
    PSK being a quantum-safe migration strategy being made available by
    some protocols, see for example IKEv2 in [RFC8784].
 
-   In general it is desirable to use a multi-PRF as a KEM combiner,
+   In general it is desirable to use a split-key PRF as a KEM combiner,
    meaning that the combiner has the properties of a PRF when keyed by
    any of its single inputs.  The following simple yet generic
    construction can be used in all IETF protocols that need to combine
@@ -435,13 +435,13 @@ Internet-Draft                KEM Combiner                     July 2023
    for KDF.  The following are RECOMMENDED Keccak-based instatiations,
    but other choices MAY be made for example to allow for future
    cryptographic agility.  A protocol using a different instantiation
-   MUST justify that it will behave as a multi-PRF.
+   MUST justify that it will behave as a split-key PRF, as required in
+   [GHP18].
 
    Each instance defines a function to be used as KDF, a hashSize to
    determine parameter size, and optionally a counter:
 
    1.  KDF = KMAC128, with hashSize = 128 bit.
-
 
 
 
@@ -458,10 +458,10 @@ Internet-Draft                KEM Combiner                     July 2023
 
    As justified in the security considerations, we recommend only
    Keccak-based instantiations because assuming there are no weaknesses
-   found in the Keccak permutation, it behaves as a multi-PRF that can
-   be keyed by any input k_i.  SHAKE is also not included in the list as
-   it is not allowed by [SP800-56A] section 7, and does not provide any
-   implementation advantage over KMAC.
+   found in the Keccak permutation, it behaves as a split-key PRF that
+   can be keyed by any input k_i.  SHAKE is also not included in the
+   list as it is not allowed by [SP800-56A] section 7, and does not
+   provide any implementation advantage over KMAC.
 
    KMAC constructions are RECOMMENDED over SHA-3, as KMAC offers a
    simple cSHAKE-based construction, with the advantage of returning an
@@ -518,7 +518,7 @@ Internet-Draft                KEM Combiner                     July 2023
 
 6.  Security Considerations
 
-   The proposed instantiations in Section 4 are practical multi-PRFs
+   The proposed instantiations in Section 4 are practical split-key PRFs
    since this specification limits to the use of Keccak-based
    constructions.  The sponge construction was proven to be
    indifferentiable from a random oracle [BDPA08].  More precisely, for


### PR DESCRIPTION
This aligns naming with Giacon et al.